### PR TITLE
Add simple stress test setup

### DIFF
--- a/src/solver-service-api/worker.ml
+++ b/src/solver-service-api/worker.ml
@@ -33,7 +33,7 @@ end
 module Solve_request = struct
   type t = {
     opam_repository_commits : (string * string) list;
-        (**Pair of repo URL and commit hash, for each opam-repository to use*)
+        (** Pair of repo URL and commit hash, for each opam-repository to use. *)
     root_pkgs : (string * string) list;
         (** Name and contents of top-level opam files. *)
     pinned_pkgs : (string * string) list;

--- a/stress/README.md
+++ b/stress/README.md
@@ -1,0 +1,13 @@
+# Stress Test
+
+The stress test communicates using the solver-service over a TCP connection, but it is still testing the underlying solver library that the worker also uses. To run the test, first start up the solver-service at some local address:
+
+```
+$ dune exec -- solver-service --address=tcp:127.0.0.1:9090
+```
+
+This should give you a capnp address to copy. Then run the stress test passing in the address:
+
+```
+$ dune exec -- stress/stress.exe capnp://...
+```

--- a/stress/dune
+++ b/stress/dune
@@ -1,0 +1,3 @@
+(executable
+ (name stress)
+ (libraries solver-worker))

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -1,0 +1,64 @@
+(* This stress test is for the underlying solver-service library
+   that the workers use to solve dependencies. *)
+open Lwt.Syntax
+
+let job_log job =
+  let module L = Solver_service_api.Raw.Service.Log in
+  L.local
+  @@ object
+       inherit L.service
+
+       method write_impl params release_param_caps =
+         let open L.Write in
+         release_param_caps ();
+         let msg = Params.msg_get params in
+         Buffer.add_string job msg;
+         Capnp_rpc_lwt.Service.(return (Response.create_empty ()))
+     end
+
+let solver_dir = "solver"
+let ocaml_package_name = "ocaml-base-compiler"
+let ocaml_version = "4.13.1"
+let opam_repository_commit = "ad79e369dfb9be127d520e0f96ca6002f6860ff9"
+
+let package_to_custom vars package =
+  let+ opamfile = Utils.get_opam_file package in
+  Solver_service_api.Worker.Solve_request.
+    {
+      opam_repository_commit;
+      root_pkgs = [ (package, opamfile) ];
+      pinned_pkgs = [];
+      platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
+    }
+
+let requests log solver =
+  let* vars = Utils.get_vars ~ocaml_package_name ~ocaml_version () in
+  let packages = [ "fmt.0.8.7"; "alcotest.1.5.0"; "yojson.1.7.0" ] in
+  let* requests = Lwt_list.map_p (package_to_custom vars) packages in
+  let before = Unix.gettimeofday () in
+  let* results =
+    Lwt_list.map_p (Solver_service_api.Solver.solve solver ~log) requests
+  in
+  let+ () =
+    Lwt_list.iter_s
+      (fun r ->
+        Lwt.return
+        @@ Yojson.Safe.pp Format.std_formatter
+        @@ Solver_service_api.Worker.Solve_response.to_yojson r)
+      results
+  in
+  before
+
+let stress () =
+  let client_vat = Capnp_rpc_unix.client_only_vat () in
+  let sr =
+    Capnp_rpc_unix.Vat.import_exn client_vat (Uri.of_string Sys.argv.(1))
+  in
+  let job = Buffer.create 1000 in
+  Capnp_rpc_lwt.Capability.with_ref (job_log job) @@ fun log ->
+  Capnp_rpc_unix.with_cap_exn sr (requests log)
+
+let () =
+  let before = Lwt_main.run (stress ()) in
+  let after = Unix.gettimeofday () in
+  Format.printf "\nSolved requests in: %f" (after -. before)

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -25,7 +25,8 @@ let package_to_custom vars package =
   let+ opamfile = Utils.get_opam_file package in
   Solver_service_api.Worker.Solve_request.
     {
-      opam_repository_commit;
+      opam_repository_commits =
+        [ ("git@github.com:ocaml/opam-repository.git", opam_repository_commit) ];
       root_pkgs = [ (package, opamfile) ];
       pinned_pkgs = [];
       platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];

--- a/stress/utils.ml
+++ b/stress/utils.ml
@@ -1,0 +1,38 @@
+open Lwt.Syntax
+
+let opam_template arch =
+  let arch = Option.value ~default:"%{arch}%" arch in
+  Fmt.str
+    {|
+  {
+    "arch": "%s",
+    "os": "%%{os}%%",
+    "os_family": "%%{os-family}%%",
+    "os_distribution": "%%{os-distribution}%%",
+    "os_version": "%%{os-version}%%",
+    "opam_version": "%%{opam-version}%%"
+  }
+|}
+    arch
+
+let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+  let+ vars =
+    Solver_service.Process.pread
+      ("", [| "opam"; "config"; "expand"; opam_template arch |])
+  in
+  let json =
+    match Yojson.Safe.from_string vars with
+    | `Assoc items ->
+        `Assoc
+          (("ocaml_package", `String ocaml_package_name)
+          :: ("ocaml_version", `String ocaml_version)
+          :: items)
+    | json ->
+        Fmt.failwith "Unexpected JSON: %a"
+          Yojson.Safe.(pretty_print ~std:true)
+          json
+  in
+  Result.get_ok @@ Solver_service_api.Worker.Vars.of_yojson json
+
+let get_opam_file pv =
+  Solver_service.Process.pread ("", [| "opam"; "show"; "--raw"; pv |])


### PR DESCRIPTION
Adds a simple stress test setup using the solver-service executable communicating over TCP with the client. We could add more packages and platforms to increase the number of requests/solves sent to the worker.