### PR TITLE
Fix an uncaught exception

### DIFF
--- a/examples/main.ml
+++ b/examples/main.ml
@@ -31,7 +31,7 @@ let opam_template arch =
     "os": "%%{os}%%",
     "os_family": "%%{os-family}%%",
     "os_distribution": "%%{os-distribution}%%",
-    "os_version": "%%{os-version}%%"
+    "os_version": "%%{os-version}%%",
     "opam_version": "%%{opam-version}%%"
   }
 |}


### PR DESCRIPTION
It ends with this exception
```
solve-local: internal error, uncaught exception:
             Yojson.Json_error("Line 8, bytes 4-33:\nExpected ',' or '}' but found '\"opam_version\": \"2.1.1\"\n  }\n\n'")
```