### PR TITLE
Make "n_workers" as a parameter

### DIFF
--- a/examples/main.ml
+++ b/examples/main.ml
@@ -70,7 +70,7 @@ let run_client ~package ~version ~opam_commit service =
     Solver_service_api.Worker.Solve_request.
       {
         opam_repository_commits =
-          [ ("github.com/ocaml/opam-repository", opam_commit) ];
+          [ ("https://github.com/ocaml/opam-repository.git", opam_commit) ];
         root_pkgs = [ (pv, opam_file) ];
         pinned_pkgs = [];
         platforms = [ (platform.os, platform) ];

--- a/src/solver-worker/bin/main.ml
+++ b/src/solver-worker/bin/main.ml
@@ -24,7 +24,10 @@ let main default_level registration_path capacity name state_dir =
   Lwt_main.run
     (let vat = Capnp_rpc_unix.client_only_vat () in
      let sr = Capnp_rpc_unix.Cap_file.load vat registration_path |> or_die in
-     let solver = Solver_worker.spawn_local ~solver_dir:state_dir () in
+     let solver =
+       Solver_worker.spawn_local ~solver_dir:state_dir
+         ~internal_workers:capacity ()
+     in
      Worker.run ~build:(build ~solver) ~capacity ~name ~state_dir sr)
 
 open Cmdliner
@@ -42,7 +45,7 @@ let connect_addr =
 
 let capacity =
   Arg.value
-  @@ Arg.opt Arg.int 10
+  @@ Arg.opt Arg.int 20
   @@ Arg.info ~doc:"The number of builds that can run in parallel" ~docv:"N"
        [ "capacity" ]
 

--- a/src/solver-worker/lib/solver_worker.mli
+++ b/src/solver-worker/lib/solver_worker.mli
@@ -23,6 +23,10 @@ val solve :
 (** [solve ~solver ~switch ~log c] interprets [c] as a solver request and solves
     it using [solver]. *)
 
-val spawn_local : ?solver_dir:string -> unit -> Solver_service_api.Solver.t
+val spawn_local :
+  ?solver_dir:string ->
+  internal_workers:int ->
+  unit ->
+  Solver_service_api.Solver.t
 (** [spawn_local ()] forks a process running a [solver-service] that
     communicates over standard input/output. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,3 +1,7 @@
 let () =
+  (* ignore user's git configuration *)
+  Unix.putenv "GIT_AUTHOR_NAME" "test";
+  Unix.putenv "GIT_COMMITTER_NAME" "test";
+  Unix.putenv "EMAIL" "test@example.com";
   Lwt_main.run
   @@ Alcotest_lwt.run "solver-service" [ ("service", Test_service.tests) ]


### PR DESCRIPTION
- The `solver-service` has now a parameter for the config of the number of thread workers that can handle more requests in parallel (`--internal-thread-workers`).
- The `solver-worker` use that parameter of `solver-service` as `--capacity`.