### PR TITLE
Replace usage of `socketpair` for IPC

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,7 @@
  (name solver-service)
  (synopsis "Choose package versions to test")
  (depends
+  (ocaml (>= 4.14.0))
   (alcotest-lwt :with-test)
   ; Examples dependencies
   (current_web :with-test)
@@ -33,6 +34,7 @@
  (name solver-service-api)
  (synopsis "Cap'n Proto API for the solver service")
  (depends
+  (ocaml (>= 4.14.0))
   (alcotest-lwt :with-test)
   current_rpc
   (capnp (>= 3.4.0))
@@ -44,6 +46,7 @@
  (name solver-worker)
  (synopsis "An OCluster worker that can solve opam constraints")
  (depends
+  (ocaml (>= 4.14.0))
   (alcotest-lwt (and (>= 1.5.0) :with-test))
   ocluster-api
   current

--- a/solver-service-api.opam
+++ b/solver-service-api.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
   "alcotest-lwt" {with-test}
   "current_rpc"
   "capnp" {>= "3.4.0"}

--- a/solver-service.opam
+++ b/solver-service.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
   "alcotest-lwt" {with-test}
   "current_web" {with-test}
   "current_github" {with-test}

--- a/solver-worker.opam
+++ b/solver-worker.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "ocluster-api"
   "current"

--- a/worker/solver_worker.ml
+++ b/worker/solver_worker.ml
@@ -59,10 +59,18 @@ let solve ~solver ~switch:_ ~log c =
       Log_data.write log response;
       Ok response
 
+let temp_file_name prefix suffix =
+  let temp_dir = Filename.get_temp_dir_name () in
+  let rnd = Random.(State.bits (get_state ())) land 0xFFFFFF in
+  Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
+
 let spawn_local ?solver_dir ~internal_workers () : Solver_service_api.Solver.t =
-  Logs.info (fun f -> f "Setting up solver...");
-  let p, c = Unix.(socketpair PF_UNIX SOCK_STREAM 0 ~cloexec:true) in
-  Unix.clear_close_on_exec c;
+  let name = temp_file_name "solver-worker" ".sock" in
+  Logs.info (fun f -> f "Setting up solver %s…" name);
+  let listener = Unix.socket ~cloexec:true PF_UNIX SOCK_STREAM 0 in
+  (try Unix.unlink name with Unix.Unix_error (Unix.ENOENT, _, _) -> ());
+  Unix.bind listener (ADDR_UNIX name);
+  Unix.listen listener 1;
   let solver_dir =
     match solver_dir with
     | None -> Fpath.to_string (Current.state_dir "solver")
@@ -74,12 +82,25 @@ let spawn_local ?solver_dir ~internal_workers () : Solver_service_api.Solver.t =
         "solver-service";
         "--internal-thread-workers";
         string_of_int internal_workers;
+        "--sockpath";
+        name;
       |] )
   in
   let _child =
-    Lwt_process.open_process_none ~cwd:solver_dir ~stdin:(`FD_move c) cmd
+    Lwt_process.open_process_none ~cwd:solver_dir ~stdin:`Close cmd
   in
   let switch = Lwt_switch.create () in
+  let p, _ =
+    match Unix.select [ listener ] [] [] 1. with
+    | [ listener' ], [], [] when listener = listener' ->
+        Unix.accept ~cloexec:true listener
+    | _ -> failwith "Solver process didn't start correctly"
+    | exception (Unix.Unix_error (Unix.EINTR, _, _) as exn) ->
+        prerr_endline "Solver process didn't start correctly";
+        raise exn
+  in
+  Unix.close listener;
+  Unix.unlink name;
   let p =
     Lwt_unix.of_unix_file_descr p
     |> Capnp_rpc_unix.Unix_flow.connect ~switch


### PR DESCRIPTION
On Windows, using a socket as standard input file descriptor is daring. Even if it may be possible, Lwt will currently outright reject it. We can, instead of passing a file descriptor to the spawned process, pass the address of the UNIX domain socket as an argument so that the sub process may open a socket itself and connect to that address.

UNIX domain sockets are supported on Windows 10 and OCaml 4.14.