### PR TITLE
Replace usage of `socketpair` for IPC

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -40,6 +40,7 @@
  (name solver-worker)
  (synopsis "An OCluster worker that can solve opam constraints")
  (depends
+  (ocaml (>= "4.14.0"))
   (alcotest-lwt (and (>= 1.5.0) :with-test))
   ocluster-api
   current

--- a/solver-worker.opam
+++ b/solver-worker.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml" {>= "4.14.0"}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "ocluster-api"
   "current"

--- a/src/solver-service/bin/main.ml
+++ b/src/solver-service/bin/main.ml
@@ -59,7 +59,7 @@ let export service ~on:socket =
 
 let start_server address ~n_workers =
   let config =
-    Capnp_rpc_unix.Vat_config.create ~secret_key:`Ephemeral address
+    Capnp_rpc_unix.Vat_config.create ~serve_tls:false ~secret_key:`Ephemeral address
   in
   let service_id =
     Capnp_rpc_unix.Vat_config.derived_id config "solver-service"


### PR DESCRIPTION
On Windows, using a socket as standard input file descriptor is daring. Even if it may be possible, Lwt will currently outright reject it. We can, instead of passing a file descriptor to the spawned process, pass the address of the UNIX domain socket as an argument so that the sub process may open a socket itself and connect to that address.

UNIX domain sockets are supported on Windows 10 and OCaml 4.14.

This PR is an other approach than #23, but doesn't work. I think it's because it tries to setup a service but it shouldn't?