### PR TITLE
Enabled solving for lower-bounds of package versions

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -39,7 +39,8 @@ module Solve_request = struct
     pinned_pkgs : (string * string) list;
         (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;  (** Possible build platforms, by ID. *)
-    prefer_oldest : bool;  (** Solve for the oldest possible versions instead of newest. *)
+    lower_bound : bool;
+        (** Solve for the oldest possible versions instead of newest. *)
   }
   [@@deriving yojson]
 end

--- a/api/worker.ml
+++ b/api/worker.ml
@@ -39,6 +39,7 @@ module Solve_request = struct
     pinned_pkgs : (string * string) list;
         (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;  (** Possible build platforms, by ID. *)
+    prefer_oldest : bool;  (** Solve for the oldest possible versions instead of newest. *)
   }
   [@@deriving yojson]
 end

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -71,6 +71,7 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
         root_pkgs = [ (pv, opam_file) ];
         pinned_pkgs = [];
         platforms = [ (platform.os, platform) ];
+        prefer_oldest = false;
       }
   in
   let job = Buffer.create 100 in

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -71,7 +71,7 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
         root_pkgs = [ (pv, opam_file) ];
         pinned_pkgs = [];
         platforms = [ (platform.os, platform) ];
-        prefer_oldest = false;
+        lower_bound = false;
       }
   in
   let job = Buffer.create 100 in

--- a/examples/submit.ml
+++ b/examples/submit.ml
@@ -110,7 +110,7 @@ let pipeline ~cluster vars () =
         root_pkgs = opamfiles;
         pinned_pkgs = [];
         platforms = [ ("os", vars) ];
-        prefer_oldest = false;
+        lower_bound = false;
       }
   in
   let selection =

--- a/examples/submit.ml
+++ b/examples/submit.ml
@@ -110,6 +110,7 @@ let pipeline ~cluster vars () =
         root_pkgs = opamfiles;
         pinned_pkgs = [];
         platforms = [ ("os", vars) ];
+        prefer_oldest = false;
       }
   in
   let selection =

--- a/service/git_context.ml
+++ b/service/git_context.ml
@@ -12,7 +12,7 @@ type t = {
       (* User-provided constraints *)
   test : OpamPackage.Name.Set.t;
   with_beta_remote : bool;
-  prefer_oldest : bool;
+  lower_bound : bool;
 }
 
 let ocaml_beta_pkg = OpamPackage.of_string "ocaml-beta.enabled"
@@ -74,7 +74,7 @@ let version_compare t (v1, opam1) (v2, opam2) =
     List.mem OpamTypes.Pkgflag_AvoidVersion (OpamFile.OPAM.flags opam2)
   in
   if avoid1 = avoid2 then
-    if t.prefer_oldest then OpamPackage.Version.compare v2 v1
+    if t.lower_bound then OpamPackage.Version.compare v2 v1
     else OpamPackage.Version.compare v1 v2
   else if avoid1 then -1
   else 1
@@ -199,6 +199,6 @@ let read_packages ?acc:(result_acc = OpamPackage.Name.Map.empty) store commit =
                result_acc)
 
 let create ?(test = OpamPackage.Name.Set.empty)
-    ?(pins = OpamPackage.Name.Map.empty) ?(prefer_oldest = false) ~constraints
+    ?(pins = OpamPackage.Name.Map.empty) ?(lower_bound = false) ~constraints
     ~env ~packages ~with_beta_remote () =
-  { env; packages; pins; constraints; test; with_beta_remote; prefer_oldest }
+  { env; packages; pins; constraints; test; with_beta_remote; lower_bound }

--- a/service/git_context.ml
+++ b/service/git_context.ml
@@ -12,6 +12,7 @@ type t = {
       (* User-provided constraints *)
   test : OpamPackage.Name.Set.t;
   with_beta_remote : bool;
+  prefer_oldest : bool;
 }
 
 let ocaml_beta_pkg = OpamPackage.of_string "ocaml-beta.enabled"
@@ -65,14 +66,16 @@ let filter_available t pkg opam =
         (OpamFilter.to_string available);
       Error Unavailable
 
-let version_compare (v1, opam1) (v2, opam2) =
+let version_compare t (v1, opam1) (v2, opam2) =
   let avoid1 =
     List.mem OpamTypes.Pkgflag_AvoidVersion (OpamFile.OPAM.flags opam1)
   in
   let avoid2 =
     List.mem OpamTypes.Pkgflag_AvoidVersion (OpamFile.OPAM.flags opam2)
   in
-  if avoid1 = avoid2 then OpamPackage.Version.compare v1 v2
+  if avoid1 = avoid2 then
+    if t.prefer_oldest then OpamPackage.Version.compare v2 v1
+    else OpamPackage.Version.compare v1 v2
   else if avoid1 then -1
   else 1
 
@@ -101,7 +104,7 @@ let candidates t name =
           in
           let user_constraints = user_restrictions t name in
           OpamPackage.Version.Map.bindings versions
-          |> List.fast_sort version_compare
+          |> List.fast_sort (version_compare t)
           |> List.rev_map (fun (v, opam) ->
                  match user_constraints with
                  | Some test
@@ -196,6 +199,6 @@ let read_packages ?acc:(result_acc = OpamPackage.Name.Map.empty) store commit =
                result_acc)
 
 let create ?(test = OpamPackage.Name.Set.empty)
-    ?(pins = OpamPackage.Name.Map.empty) ~constraints ~env ~packages
-    ~with_beta_remote () =
-  { env; packages; pins; constraints; test; with_beta_remote }
+    ?(pins = OpamPackage.Name.Map.empty) ?(prefer_oldest = false) ~constraints
+    ~env ~packages ~with_beta_remote () =
+  { env; packages; pins; constraints; test; with_beta_remote; prefer_oldest }

--- a/service/git_context.ml
+++ b/service/git_context.ml
@@ -66,7 +66,7 @@ let filter_available t pkg opam =
         (OpamFilter.to_string available);
       Error Unavailable
 
-let version_compare t (v1, opam1) (v2, opam2) =
+let version_compare lower_bound (v1, opam1) (v2, opam2) =
   let avoid1 =
     List.mem OpamTypes.Pkgflag_AvoidVersion (OpamFile.OPAM.flags opam1)
   in
@@ -74,7 +74,7 @@ let version_compare t (v1, opam1) (v2, opam2) =
     List.mem OpamTypes.Pkgflag_AvoidVersion (OpamFile.OPAM.flags opam2)
   in
   if avoid1 = avoid2 then
-    if t.lower_bound then OpamPackage.Version.compare v2 v1
+    if lower_bound then OpamPackage.Version.compare v2 v1
     else OpamPackage.Version.compare v1 v2
   else if avoid1 then -1
   else 1
@@ -104,7 +104,7 @@ let candidates t name =
           in
           let user_constraints = user_restrictions t name in
           OpamPackage.Version.Map.bindings versions
-          |> List.fast_sort (version_compare t)
+          |> List.fast_sort (version_compare t.lower_bound)
           |> List.rev_map (fun (v, opam) ->
                  match user_constraints with
                  | Some test

--- a/service/git_context.mli
+++ b/service/git_context.mli
@@ -11,7 +11,7 @@ val read_packages :
 val create :
   ?test:OpamPackage.Name.Set.t ->
   ?pins:(OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
-  ?prefer_oldest:bool ->
+  ?lower_bound:bool ->
   constraints:OpamFormula.version_constraint OpamPackage.Name.Map.t ->
   env:(string -> OpamVariable.variable_contents option) ->
   packages:OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t ->

--- a/service/git_context.mli
+++ b/service/git_context.mli
@@ -11,6 +11,7 @@ val read_packages :
 val create :
   ?test:OpamPackage.Name.Set.t ->
   ?pins:(OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
+  ?prefer_oldest:bool ->
   constraints:OpamFormula.version_constraint OpamPackage.Name.Map.t ->
   env:(string -> OpamVariable.variable_contents option) ->
   packages:OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t ->

--- a/service/service.ml
+++ b/service/service.ml
@@ -145,7 +145,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         platforms;
         root_pkgs;
         pinned_pkgs;
-        lower_bound = _lower_bound;
+        lower_bound = _;
       } =
         request
       in

--- a/service/service.ml
+++ b/service/service.ml
@@ -145,6 +145,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         platforms;
         root_pkgs;
         pinned_pkgs;
+        prefer_oldest = _prefer_oldest;
       } =
         request
       in

--- a/service/service.ml
+++ b/service/service.ml
@@ -145,7 +145,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         platforms;
         root_pkgs;
         pinned_pkgs;
-        prefer_oldest = _prefer_oldest;
+        lower_bound = _lower_bound;
       } =
         request
       in

--- a/service/solver.ml
+++ b/service/solver.ml
@@ -13,7 +13,7 @@ let parse_opam (name, contents) =
   let opam = OpamFile.OPAM.read_from_string contents in
   (OpamPackage.name pkg, (OpamPackage.version pkg, opam))
 
-let solve ~packages ~pins ~root_pkgs ~prefer_oldest (vars : Worker.Vars.t) =
+let solve ~packages ~pins ~root_pkgs ~lower_bound (vars : Worker.Vars.t) =
   let ocaml_package = OpamPackage.Name.of_string vars.ocaml_package in
   let ocaml_version = OpamPackage.Version.of_string vars.ocaml_version in
   let context =
@@ -23,7 +23,7 @@ let solve ~packages ~pins ~root_pkgs ~prefer_oldest (vars : Worker.Vars.t) =
       ~test:(OpamPackage.Name.Set.of_list root_pkgs)
       ~with_beta_remote:
         Ocaml_version.(Releases.is_dev (of_string_exn vars.ocaml_version))
-      ~prefer_oldest
+      ~lower_bound
   in
   let t0 = Unix.gettimeofday () in
   let r = Solver.solve context (ocaml_package :: root_pkgs) in
@@ -63,7 +63,7 @@ let main commits =
           root_pkgs;
           pinned_pkgs;
           platforms;
-          prefer_oldest;
+          lower_bound;
         } =
           request
         in
@@ -79,7 +79,7 @@ let main commits =
         |> List.iter (fun (_id, platform) ->
                let msg =
                  match
-                   solve ~packages ~pins ~root_pkgs ~prefer_oldest platform
+                   solve ~packages ~pins ~root_pkgs ~lower_bound platform
                  with
                  | Ok packages -> "+" ^ String.concat " " packages
                  | Error msg -> "-" ^ msg

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -29,7 +29,7 @@ let package_to_custom vars package =
       root_pkgs = [ (package, opamfile) ];
       pinned_pkgs = [];
       platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
-      prefer_oldest = false;
+      lower_bound = false;
     }
 
 let requests log solver =

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -29,6 +29,7 @@ let package_to_custom vars package =
       root_pkgs = [ (package, opamfile) ];
       pinned_pkgs = [];
       platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
+      prefer_oldest = false;
     }
 
 let requests log solver =

--- a/stress/stress_submit.ml
+++ b/stress/stress_submit.ml
@@ -51,6 +51,7 @@ let make_requests limit =
               pinned_pkgs = [];
               platforms =
                 [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
+              prefer_oldest = false;
             }
         in
         (request :: requests, nth + 1))

--- a/stress/stress_submit.ml
+++ b/stress/stress_submit.ml
@@ -51,7 +51,7 @@ let make_requests limit =
               pinned_pkgs = [];
               platforms =
                 [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
-              prefer_oldest = false;
+              lower_bound = false;
             }
         in
         (request :: requests, nth + 1))

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -14,7 +14,7 @@ let job_log job =
          Capnp_rpc_lwt.Service.(return (Response.create_empty ()))
      end
 
-module Procress = struct
+module Process = struct
   let const_response ~response : Lwt_process.process =
     object
       val std_out =
@@ -38,7 +38,7 @@ end
 module Service = Solver_service.Service.Make (Mock_opam_repo)
 
 let test_good_packages _sw () =
-  let proc = Procress.const_response ~response:"+lwt.5.5.0 yaml.3.0.0" in
+  let proc = Process.const_response ~response:"+lwt.5.5.0 yaml.3.0.0" in
   let log = Buffer.create 100 in
   let req =
     Solver_service_api.Worker.Solve_request.
@@ -51,6 +51,7 @@ let test_good_packages _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
+        prefer_oldest = false;
       }
   in
   let+ process =
@@ -63,7 +64,7 @@ let test_good_packages _sw () =
 
 let test_error _sw () =
   let msg = "Something went wrong!" in
-  let proc = Procress.const_response ~response:("-" ^ msg) in
+  let proc = Process.const_response ~response:("-" ^ msg) in
   let log = Buffer.create 100 in
   let req =
     Solver_service_api.Worker.Solve_request.
@@ -76,6 +77,7 @@ let test_error _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
+        prefer_oldest = false;
       }
   in
   let+ process =
@@ -97,7 +99,7 @@ let test_e2e _sw () =
     Utils.get_vars ~ocaml_package_name:"ocaml" ~ocaml_version:"4.13.1" ()
   in
   let create_worker _hash =
-    Procress.const_response ~response:"+lwt.5.5.0 yaml.3.0.0"
+    Process.const_response ~response:"+lwt.5.5.0 yaml.3.0.0"
   in
   let log = Buffer.create 100 in
   let req =
@@ -107,6 +109,7 @@ let test_e2e _sw () =
         root_pkgs = [ ("yaml.3.0.0", "") ];
         pinned_pkgs = [];
         platforms = [ (os_id, vars) ];
+        prefer_oldest = false;
       }
   in
   let* service = Service.v ~n_workers:1 ~create_worker in

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -113,8 +113,12 @@ let test_e2e _sw () =
       }
   in
   let* service = Service.v ~n_workers:1 ~create_worker in
-  let+ response =
+  let* response =
     Solver_service_api.Solver.solve ~log:(job_log log) service req
+  in
+  let req_lower_bound = { req with lower_bound = true } in
+  let+ response_lower_bound =
+    Solver_service_api.Solver.solve ~log:(job_log log) service req_lower_bound
   in
   Alcotest.(check solver_response)
     "Same solve reponse"
@@ -127,7 +131,19 @@ let test_e2e _sw () =
            commits;
          };
        ])
-    response
+    response;
+  Alcotest.(check solver_response)
+    "Same solve reponse"
+    (Ok
+       [
+         {
+           id = os_id;
+           packages = [ "lwt.5.5.0"; "yaml.3.0.0" ];
+           compat_pkgs = [ "yaml.3.0.0" ];
+           commits;
+         };
+       ])
+    response_lower_bound
 
 let tests =
   Alcotest_lwt.

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -51,7 +51,7 @@ let test_good_packages _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        prefer_oldest = false;
+        lower_bound = false;
       }
   in
   let+ process =
@@ -77,7 +77,7 @@ let test_error _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        prefer_oldest = false;
+        lower_bound = false;
       }
   in
   let+ process =
@@ -109,7 +109,7 @@ let test_e2e _sw () =
         root_pkgs = [ ("yaml.3.0.0", "") ];
         pinned_pkgs = [];
         platforms = [ (os_id, vars) ];
-        prefer_oldest = false;
+        lower_bound = false;
       }
   in
   let* service = Service.v ~n_workers:1 ~create_worker in


### PR DESCRIPTION
This functionality is exposed with a new boolean flag in the `Solve_request` struct in `api/worker.ml`. This is a breaking change for existing programs instantiating the request struct directly, such as OCaml-CI.

Is this OK?
(I will introduce a PR making the required change in OCaml-CI also.)