### PR TITLE
File descriptor leaks

### DIFF
--- a/service/process.ml
+++ b/service/process.ml
@@ -24,10 +24,10 @@ let check_status cmd = function
   | status -> Fmt.failwith "%a %a" pp_cmd cmd pp_status status
 
 let exec cmd =
-  let proc = Lwt_process.open_process_none cmd in
-  proc#status >|= check_status cmd
+  Lwt_process.with_process_none cmd (fun proc ->
+      proc#status >|= check_status cmd)
 
 let pread cmd =
-  let proc = Lwt_process.open_process_in cmd in
-  Lwt_io.read proc#stdout >>= fun output ->
-  proc#status >|= check_status cmd >|= fun () -> output
+  Lwt_process.with_process_in cmd (fun proc ->
+      Lwt_io.read proc#stdout >>= fun output ->
+      proc#status >|= check_status cmd >|= fun () -> output)

--- a/service/process.ml
+++ b/service/process.ml
@@ -24,10 +24,10 @@ let check_status cmd = function
   | status -> Fmt.failwith "%a %a" pp_cmd cmd pp_status status
 
 let exec cmd =
-  Lwt_process.with_process_none cmd (fun proc ->
-      proc#status >|= check_status cmd)
+  Lwt_process.with_process_none cmd @@ fun proc ->
+  proc#status >|= check_status cmd
 
 let pread cmd =
-  Lwt_process.with_process_in cmd (fun proc ->
-      Lwt_io.read proc#stdout >>= fun output ->
-      proc#status >|= check_status cmd >|= fun () -> output)
+  Lwt_process.with_process_in cmd @@ fun proc ->
+  Lwt_io.read proc#stdout >>= fun output ->
+  proc#status >|= check_status cmd >|= fun () -> output

--- a/service/service.ml
+++ b/service/service.ml
@@ -45,6 +45,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
     let dispose (worker : Lwt_process.process) =
       let pid = worker#pid in
       Fmt.epr "Terminating worker %d@." pid;
+      worker#terminate;
       worker#close >|= function
       | Unix.WEXITED code ->
           Fmt.epr "Worker %d finished@. Exited with code %d" pid code

--- a/worker/process.ml
+++ b/worker/process.ml
@@ -19,29 +19,29 @@ let exec ~label ~log ~switch ?env ?(stdin = "") ?(stderr = `FD_copy Unix.stdout)
   Log.info (fun f ->
       f "Exec(%s): %a" label Fmt.(list ~sep:sp (quote string)) cmd);
   let cmd = ("", Array.of_list cmd) in
-  Lwt_process.with_process ?env ~stderr cmd (fun proc ->
-      Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
-          if Lwt.state proc#status = Lwt.Sleep then (
-            Log.info (fun f -> f "Cancelling %s job..." label);
-            proc#terminate);
-          Lwt.return_unit)
-      >>= fun () ->
-      let copy_thread = Log_data.copy_from_stream log proc#stdout in
-      send_to proc#stdin stdin >>= fun stdin_result ->
-      copy_thread >>= fun () ->
-      (* Ensure all data has been copied before returning *)
-      proc#status >|= function
-      | _ when not (Lwt_switch.is_on switch) -> Error `Cancelled
-      | Unix.WEXITED n when is_success n -> (
-          match stdin_result with
-          | Ok () -> Ok ()
-          | Error (`Msg msg) ->
-              Error (`Msg (Fmt.str "Failed sending input to %s: %s" label msg)))
-      | Unix.WEXITED n -> Error (`Exit_code n)
-      | Unix.WSIGNALED x ->
-          Error (`Msg (Fmt.str "%s failed with signal %d" label x))
-      | Unix.WSTOPPED x ->
-          Error (`Msg (Fmt.str "%s stopped with signal %a" label pp_signal x)))
+  Lwt_process.with_process ?env ~stderr cmd @@ fun proc ->
+  Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
+      if Lwt.state proc#status = Lwt.Sleep then (
+        Log.info (fun f -> f "Cancelling %s job..." label);
+        proc#terminate);
+      Lwt.return_unit)
+  >>= fun () ->
+  let copy_thread = Log_data.copy_from_stream log proc#stdout in
+  send_to proc#stdin stdin >>= fun stdin_result ->
+  copy_thread >>= fun () ->
+  (* Ensure all data has been copied before returning *)
+  proc#status >|= function
+  | _ when not (Lwt_switch.is_on switch) -> Error `Cancelled
+  | Unix.WEXITED n when is_success n -> (
+      match stdin_result with
+      | Ok () -> Ok ()
+      | Error (`Msg msg) ->
+          Error (`Msg (Fmt.str "Failed sending input to %s: %s" label msg)))
+  | Unix.WEXITED n -> Error (`Exit_code n)
+  | Unix.WSIGNALED x ->
+      Error (`Msg (Fmt.str "%s failed with signal %d" label x))
+  | Unix.WSTOPPED x ->
+      Error (`Msg (Fmt.str "%s stopped with signal %a" label pp_signal x))
 
 let check_call ~label ~log ~switch ?env ?stdin ?stderr ?is_success cmd =
   exec ~label ~log ~switch ?env ?stdin ?stderr ?is_success cmd >|= function


### PR DESCRIPTION
This PR intends to fix the `Unix.EMFILE` that happens when too many file descriptors are opened simultaneously.

It tackles the problem at various places in the code, as suggested by @TheLortex (Thanks :pray: ):
- [service/service.ml](https://github.com/ocurrent/solver-service/blob/8232d6c0521cd2834e8eb6302f6bdfc00263fb8b/service/service.ml#L45): the `dispose` function only terminates the process and don't close the descriptor that might stay. This is the point that was creating the issue from my tests, but it's a hypothesis. In the code version, we ensure it closes everything.
- [worker/process.ml](https://github.com/ocurrent/solver-service/blob/8232d6c0521cd2834e8eb6302f6bdfc00263fb8b/worker/process.ml#L17): the exec only terminate the proc in case of cancellation. By encapsulating it in the `Lwt_process.with_process`, we ensure it executes a `close` at the end at least.
- [service/process.ml](https://github.com/ocurrent/solver-service/blob/8232d6c0521cd2834e8eb6302f6bdfc00263fb8b/service/process.ml): the `exec` and `pread` are wrapped into a `Lwt_process.with_process` to ensure it also executes a `close`  at the end.

:warning: This is a PR that has been tested with a local setup so it needs to __be deployed at some point__ to make sure it fixes the problem.