### PR TITLE
Run dune subst to include cli version information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN opam pin add -yn current_docker.dev "./ocurrent" && \
 
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
+RUN opam exec -- dune subst
 RUN opam exec -- dune build ./_build/install/default/bin/solver-service
 RUN opam exec -- dune build ./_build/install/default/bin/solver-worker
 


### PR DESCRIPTION
I noticed the version information wasn't available on the solver workers. 
Looks like we missed running `dune subst` in the Dockerfile.

This PR corrects that omission and I have tested this locally.
See https://github.com/ocurrent/ocluster/pull/178 for when a similar fix was added for ocluster.