### PR TITLE
Use dune install to add version information to executables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,15 @@ RUN opam pin add -yn current_docker.dev "./ocurrent" && \
 
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
-RUN opam exec -- dune subst
-RUN opam exec -- dune build ./_build/install/default/bin/solver-service
-RUN opam exec -- dune build ./_build/install/default/bin/solver-worker
+RUN opam config exec -- dune build -p solver-service,solver-service-api,solver-worker @install
+RUN opam config exec -- dune install --prefix=/usr/local --destdir=pkg --section=bin --relocatable solver-worker solver-service
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install docker.io libev4 curl gnupg2 git libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 WORKDIR /var/lib/ocluster-worker
 ENTRYPOINT ["/usr/local/bin/solver-worker"]
 ENV PROGRESS_NO_TRUNC=1
-COPY --from=build /src/_build/install/default/bin/solver-worker /src/_build/install/default/bin/solver-service /usr/local/bin/
+COPY --from=build \
+    /src/pkg/usr/local/bin/solver-worker \
+    /src/pkg/usr/local/bin/solver-service \
+    /usr/local/bin/

--- a/service/dune
+++ b/service/dune
@@ -11,6 +11,7 @@
   capnp-rpc-unix
   git-unix
   ocaml-version
+  dune-build-info
   str
   fmt.cli
   fmt.tty)

--- a/service/main.ml
+++ b/service/main.ml
@@ -149,9 +149,14 @@ let sockpath =
           will use stdin."
        ~docv:"SOCKPATH" [ "sockpath" ]
 
+let version =
+  match Build_info.V1.version () with
+  | None -> "n/a"
+  | Some v -> Build_info.V1.Version.to_string v
+
 let cmd =
   let doc = "Solver for ocaml-ci" in
-  let info = Cmd.info "solver-service" ~doc in
+  let info = Cmd.info "solver-service" ~doc ~version in
   Cmd.v info
     Term.(
       const main


### PR DESCRIPTION
The previous approach using `dune subst` was not producing binaries with version information.

```
$ docker pull ocurrent/solver-service:live
$ docker image ls 
REPOSITORY                TAG       IMAGE ID       CREATED         SIZE
ocurrent/solver-service   live      eba01b2690c8   14 hours ago    567MB
$ docker run -it --entrypoint /bin/bash eba01b2690c8
root@07bfc220368b:/var/lib/ocluster-worker# /usr/local/bin/solver-worker --version
n/a
```

I suspect the [copying hack](https://github.com/ocurrent/solver-service/blob/main/worker/dune#L18-L34) we have for depending on solver-service might be responsible. But I've not debugged into the dune source code for what is going on exactly.

Using dune install reliably produces a binary with version information.

```
$ docker build -t solver-service -f Dockerfile .
$ docker image ls
REPOSITORY                TAG       IMAGE ID       CREATED          SIZE
solver-service            latest    0fb0e2680187   13 minutes ago   567MB
$ docker run -it --entrypoint /bin/bash 0fb0e2680187
root@b14fe72206fb:/var/lib/ocluster-worker# /usr/local/bin/solver-worker --version
83cf768-dirty
```

Based off the discussion here https://github.com/ocurrent/ocluster/pull/178 and @MisterDA 's suggestion