### PR TITLE
Close all unused file descriptors opened by git-unix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-22.04-ocaml-4.14@sha256:cdc3ec85f42f2daaea17db5024405a9f8f0c83766d35626078eb0c33aa1a8b53 AS build
+FROM ocaml/opam:ubuntu-22.04-ocaml-4.14@sha256:1e42940a3a666fe90409091218445fb763fc424d356815d291f4daa44f0db54f AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 1781c7c1cc5fcf754c394722952341200ec2eb01 && opam update
 COPY --chown=opam solver-service.opam solver-service-api.opam solver-worker.opam /src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:ubuntu-22.04-ocaml-4.14@sha256:cdc3ec85f42f2daaea17db5024405a9f8f0c83766d35626078eb0c33aa1a8b53 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 1443067283649a4e09423a4a9a7b082c70e0227b && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 1781c7c1cc5fcf754c394722952341200ec2eb01 && opam update
 COPY --chown=opam solver-service.opam solver-service-api.opam solver-worker.opam /src/
 
 COPY --chown=opam \

--- a/dune-project
+++ b/dune-project
@@ -26,10 +26,10 @@
   (solver-service-api (= :version))
   conf-libev
   (opam-0install (>= "0.4.3"))
-  (git-unix (>= 3.2.0))
+  (git-unix (>= 3.12.0))
   (capnp-rpc-unix (>= 1.2)))
  (conflicts (carton (< 0.4.2))))
- 
+
 (package
  (name solver-service-api)
  (synopsis "Cap'n Proto API for the solver service")
@@ -41,7 +41,7 @@
   capnp-rpc-lwt
   ppx_deriving
   ppx_deriving_yojson))
- 
+
 (package
  (name solver-worker)
  (synopsis "An OCluster worker that can solve opam constraints")

--- a/service/opam_repository.ml
+++ b/service/opam_repository.ml
@@ -51,6 +51,8 @@ let open_store ?(repo_url = default_repo_url) () =
   | Error e ->
       Fmt.failwith "Failed to open %a: %a" Fpath.pp path Store.pp_error e
 
+let close_store store = Git_unix.Store.close_pack_files store
+
 let oldest_commit_with ~repo_url ~from paths =
   let clone_path = repo_url_to_clone_path repo_url |> Fpath.to_string in
   let cmd =

--- a/service/opam_repository_intf.ml
+++ b/service/opam_repository_intf.ml
@@ -5,7 +5,7 @@ module type S = sig
       defaults to ocaml/opam-repository on GitHub. *)
 
   val close_store : Git_unix.Store.t -> unit Lwt.t
-  (** [close_store t] close all file descriptors used by t *)
+  (** [close_store t] closes all file descriptors used by [t] *)
 
   val clone : ?repo_url:string -> unit -> unit Lwt.t
   (** [clone ()] ensures that a local clone of the specified repo exists. If

--- a/service/opam_repository_intf.ml
+++ b/service/opam_repository_intf.ml
@@ -4,6 +4,9 @@ module type S = sig
       not yet exist, this clones it first. If repo_url is unspecified, it
       defaults to ocaml/opam-repository on GitHub. *)
 
+  val close_store : Git_unix.Store.t -> unit Lwt.t
+  (** [close_store t] close all file descriptors used by t *)
+
   val clone : ?repo_url:string -> unit -> unit Lwt.t
   (** [clone ()] ensures that a local clone of the specified repo exists. If
       not, it clones it. If repo_url is unspecified, it defaults to

--- a/service/service.ml
+++ b/service/service.ml
@@ -58,19 +58,18 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
       let repo_url = commit.Remote_commit.repo in
       let hash = Store.Hash.of_hex commit.Remote_commit.hash in
       Opam_repo.open_store ~repo_url () >>= fun store ->
-      Store.mem store hash >>= function
-      | true -> Opam_repo.close_store store
-      | false -> (
-          Opam_repo.close_store store >>= fun () ->
-          Fmt.pr "Need to update %s to get new commit %a@." repo_url
-            Store.Hash.pp hash;
-          Opam_repo.fetch ~repo_url () >>= fun () ->
-          Opam_repo.open_store ~repo_url () >>= fun new_store ->
-          Store.mem new_store hash >>= function
-          | false ->
-              Opam_repo.close_store new_store >>= fun () ->
-              Fmt.failwith "Still missing commit after update!"
-          | true -> Opam_repo.close_store new_store)
+      Store.mem store hash >>= fun r ->
+      Opam_repo.close_store store >>= fun () ->
+      if r then Lwt.return_unit
+      else (
+        Fmt.pr "Need to update %s to get new commit %a@." repo_url Store.Hash.pp
+          hash;
+        Opam_repo.fetch ~repo_url () >>= fun () ->
+        Opam_repo.open_store ~repo_url () >>= fun new_store ->
+        Store.mem new_store hash >>= fun r ->
+        Opam_repo.close_store new_store >>= fun () ->
+        if r then Lwt.return_unit
+        else Fmt.failwith "Still missing commit after update!")
     (*Closing the store after usage is necessary to prevent file descriptor leaks*)
 
     let create ~n_workers ~create_worker commits =

--- a/service/service.ml
+++ b/service/service.ml
@@ -59,15 +59,19 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
       let hash = Store.Hash.of_hex commit.Remote_commit.hash in
       Opam_repo.open_store ~repo_url () >>= fun store ->
       Store.mem store hash >>= function
-      | true -> Lwt.return_unit
+      | true -> Opam_repo.close_store store
       | false -> (
+          Opam_repo.close_store store >>= fun () ->
           Fmt.pr "Need to update %s to get new commit %a@." repo_url
             Store.Hash.pp hash;
           Opam_repo.fetch ~repo_url () >>= fun () ->
           Opam_repo.open_store ~repo_url () >>= fun new_store ->
           Store.mem new_store hash >>= function
-          | false -> Fmt.failwith "Still missing commit after update!"
-          | true -> Lwt.return_unit)
+          | false ->
+              Opam_repo.close_store new_store >>= fun () ->
+              Fmt.failwith "Still missing commit after update!"
+          | true -> Opam_repo.close_store new_store)
+    (*Closing the store after usage is necessary to prevent file descriptor leaks*)
 
     let create ~n_workers ~create_worker commits =
       Lwt_list.iter_p update_opam_repository_to_commit commits >|= fun () ->

--- a/solver-service.opam
+++ b/solver-service.opam
@@ -22,7 +22,7 @@ depends: [
   "solver-service-api" {= version}
   "conf-libev"
   "opam-0install" {>= "0.4.3"}
-  "git-unix" {>= "3.2.0"}
+  "git-unix" {>= "3.12.0"}
   "capnp-rpc-unix" {>= "1.2"}
   "odoc" {with-doc}
 ]

--- a/test/mock_opam_repo.ml
+++ b/test/mock_opam_repo.ml
@@ -57,3 +57,4 @@ let open_store ?repo_url:_ () =
 let clone ?repo_url:_ () = Lwt.return ()
 let oldest_commits_with ~from:_ _pkgs = commits
 let fetch ?repo_url:_ () = Lwt.return ()
+let close_store store = Git_unix.Store.close_pack_files store


### PR DESCRIPTION
Opening a store, open also some file descriptors. In the case of solver-service we're opening a store for each new hash commit of opam-repository. A store is not reused and we ends up accumulating lot of file descriptors.

This PR solve one of those issues https://github.com/ocurrent/solver-service/issues/46.