### PR TITLE
Pipeline stress auto cancel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = ocaml-dockerfile
 	url = https://github.com/ocurrent/ocaml-dockerfile.git
 	branch = master
+[submodule "ocaml-ci"]
+	path = ocaml-ci
+	url = https://github.com/ocurrent/ocaml-ci.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = ocaml-ci
 	url = https://github.com/ocurrent/ocaml-ci.git
 	branch = master
+[submodule "ocaml-version"]
+	path = ocaml-version
+	url = https://github.com/ocurrent/ocaml-version.git
+	branch = master

--- a/api/worker.ml
+++ b/api/worker.ml
@@ -11,6 +11,7 @@ module Vars = struct
     ocaml_package : string;
     ocaml_version : string;
     opam_version : string;
+    lower_bound : bool;
   }
   [@@deriving yojson]
 end
@@ -25,6 +26,7 @@ module Selection = struct
     commits : (string * string) list; [@deriving yojson]
         (** The commits in each opam-repository to use. A pair of the repo URL
             and the commit hash*)
+    lower_bound : bool;  (** Is this a lower-bound selection? *)
   }
   [@@deriving yojson, ord]
 end
@@ -39,8 +41,6 @@ module Solve_request = struct
     pinned_pkgs : (string * string) list;
         (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;  (** Possible build platforms, by ID. *)
-    lower_bound : bool;
-        (** Solve for the oldest possible versions instead of newest. *)
   }
   [@@deriving yojson]
 end

--- a/dune
+++ b/dune
@@ -1,3 +1,3 @@
 (dirs :standard \ var)
 
-(vendored_dirs ocluster ocurrent ocaml-dockerfile)
+(vendored_dirs ocluster ocurrent ocaml-dockerfile ocaml-ci)

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -35,7 +35,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -46,6 +47,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"
@@ -71,7 +73,6 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
         root_pkgs = [ (pv, opam_file) ];
         pinned_pkgs = [];
         platforms = [ (platform.os, platform) ];
-        lower_bound = false;
       }
   in
   let job = Buffer.create 100 in

--- a/examples/solve.ml
+++ b/examples/solve.ml
@@ -101,7 +101,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Lwt_process.pread ("", [| "opam"; "config"; "expand"; opam_template arch |])
   in
@@ -111,6 +112,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"

--- a/examples/submit.ml
+++ b/examples/submit.ml
@@ -110,7 +110,6 @@ let pipeline ~cluster vars () =
         root_pkgs = opamfiles;
         pinned_pkgs = [];
         platforms = [ ("os", vars) ];
-        lower_bound = false;
       }
   in
   let selection =

--- a/service/service.ml
+++ b/service/service.ml
@@ -137,7 +137,6 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         platforms;
         root_pkgs;
         pinned_pkgs;
-        lower_bound = _;
       } =
         request
       in
@@ -191,7 +190,15 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
                      ~from:opam_repository_commits )
                  >|= fun commits ->
                  let compat_pkgs = List.map fst compatible_root_pkgs in
-                 (id, Ok { Worker.Selection.id; compat_pkgs; packages; commits }))
+                 ( id,
+                   Ok
+                     {
+                       Worker.Selection.id;
+                       compat_pkgs;
+                       packages;
+                       commits;
+                       lower_bound = vars.lower_bound;
+                     } ))
       >|= List.filter_map (fun (id, result) ->
               Log.info log "= %s =" id;
               match result with

--- a/stress/README.md
+++ b/stress/README.md
@@ -15,8 +15,9 @@ $ dune exec -- stress/stress.exe capnp://...
 Use this to submit stress tests to a possibly remote scheduler handling a solver-worker.
 By default the number of request is limited to 30 (--limit). Make sure, the
 cache of the solver-worker is reset. It means using `rm -r var/solver` by finding where `var` directory is
-stored if solver-worker use it(`--state-dir=var`) and restart solver-worker.
+stored if solver-worker use it(`--state-dir=var`) and restart solver-worker. It is also possible to
+variate the opam-repository commit without removing solver-worker cache each time.
 
 ```
-$ dune exec -- stress/stress_submit.exe --submission-service submission.cap --limit N
+$ dune exec -- stress/stress_submit.exe --submission-service submission.cap --limit N [--opam-repository COMMIT]
 ```

--- a/stress/README.md
+++ b/stress/README.md
@@ -19,5 +19,13 @@ stored if solver-worker use it(`--state-dir=var`) and restart solver-worker. It 
 variate the opam-repository commit without removing solver-worker cache each time.
 
 ```
-$ dune exec -- stress/stress_submit.exe --submission-service submission.cap --limit N [--opam-repository COMMIT]
+$ dune exec -- stress/stress_submit.exe --submission-service submission.cap --limit N [--opam-repository-commit COMMIT]
+```
+
+To stress test the solver-worker against different opam-repository commits changing in time: almost same as previous
+the difference is the timing (by default `--time=80` seconds) of a particular opam-repository (how long it remains before change)
+and the list of opam-repository commits by default there's a list of 3 different commits.
+
+```
+$ dune exec -- stress/stress_auto_cancel_submit.exe --submission-service submission.cap --limit N --timing N [--opam-repository-commits=COMMITS]
 ```

--- a/stress/dune
+++ b/stress/dune
@@ -1,15 +1,15 @@
 ; No-op test to attach stress.exe to the solver-service package
 
 (tests
- (names stress stress_submit)
+ (names stress stress_submit stress_submit_auto_cancel)
  (package solver-worker)
  (libraries
   solver-worker
   current_ocluster
   current_web
-  ocaml-ci-service
   logs.cli
   logs.fmt
+  ocaml-version
   fmt.cli)
  (preprocess
   (pps ppx_deriving_yojson))

--- a/stress/dune
+++ b/stress/dune
@@ -7,6 +7,7 @@
   solver-worker
   current_ocluster
   current_web
+  ocaml-ci-service
   logs.cli
   logs.fmt
   fmt.cli)

--- a/stress/dune
+++ b/stress/dune
@@ -3,5 +3,13 @@
 (tests
  (names stress stress_submit)
  (package solver-worker)
- (libraries solver-worker current_ocluster logs.cli logs.fmt fmt.cli)
+ (libraries
+  solver-worker
+  current_ocluster
+  current_web
+  logs.cli
+  logs.fmt
+  fmt.cli)
+ (preprocess
+  (pps ppx_deriving_yojson))
  (action (progn)))

--- a/stress/pipeline_stages.ml
+++ b/stress/pipeline_stages.ml
@@ -1,0 +1,237 @@
+open Lwt.Infix
+open Current.Syntax
+
+let ( >>!= ) = Lwt_result.bind
+
+let solve_to_custom req builder =
+  let params =
+    Yojson.Safe.to_string
+    @@ Solver_service_api.Worker.Solve_request.to_yojson req
+  in
+  let builder =
+    Solver_service_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
+  in
+  Solver_service_api.Raw.Builder.Solver.Solve.Params.request_set builder params
+
+let remote_solve cluster job request =
+  let action =
+    Cluster_api.Submission.custom_build
+    @@ Cluster_api.Custom.v ~kind:"solve"
+    @@ solve_to_custom request
+  in
+  let build_pool =
+    Current_ocluster.Connection.pool ~job ~pool:"solver" ~action ~cache_hint:""
+      cluster
+  in
+  Current.Job.start_with ~pool:build_pool job ~level:Current.Level.Average
+  >>= fun build_job ->
+  Capnp_rpc_lwt.Capability.with_ref build_job
+    (Current_ocluster.Connection.run_job ~job)
+
+let make_request opam_package opam_repository_commit =
+  let package, opamfile = opam_package in
+  Solver_service_api.Worker.Solve_request.
+    {
+      opam_repository_commits =
+        [
+          ( "https://github.com/ocaml/opam-repository.git",
+            opam_repository_commit );
+        ];
+      root_pkgs = [ (String.cat package ".opam", opamfile) ];
+      pinned_pkgs = [];
+      platforms = [];
+      lower_bound = false;
+    }
+
+module Packages = struct
+  let id = "opam-packages"
+  let pool = Lwt_pool.create 10 (fun () -> Lwt.return_unit)
+
+  type t = No_context
+
+  module Key = Current.String
+
+  module Value = struct
+    type t = int [@@deriving yojson]
+
+    let digest t = string_of_int t
+  end
+
+  module Outcome = struct
+    type t = (string * string) list [@@deriving yojson]
+    (** package name and opam file content*)
+
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error e -> failwith e
+  end
+
+  let pp f (_, v) = Fmt.pf f "opam-packages: %s" (Value.digest v)
+
+  let run No_context job _key limit =
+    let open Lwt.Syntax in
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Utils.get_opam_packages () >>= fun pkgs ->
+    pkgs
+    |> List.filteri (fun n _ -> if n < limit + 1 then true else false)
+    |> List.mapi (fun id pkg ->
+           (* use sequential map to avoid crashing if there's a log of packages (like 100 or 200),
+               * this is because of get_opam_file which spawn a process*)
+           Lwt_pool.use pool @@ fun () ->
+           let* opamfile = Utils.get_opam_file pkg in
+           Current.Job.log job "package %d: %s@." id pkg;
+           Lwt.return (pkg, opamfile))
+    |> Lwt_list.map_s (fun p -> p)
+    >>= Lwt_result.return
+
+  let auto_cancel = true
+  let latched = true
+end
+
+module Analysis = struct
+  open Solver_service_api
+
+  let id = "analysis"
+
+  type t = Current_ocluster.Connection.t
+
+  module Key = Current.String
+
+  module Value = struct
+    type t = Worker.Solve_request.t
+
+    let digest t = Worker.Solve_request.to_yojson t |> Yojson.Safe.to_string
+  end
+
+  module Outcome = struct
+    type t = Worker.Selection.t list [@@deriving yojson]
+
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error e -> failwith e
+  end
+
+  let pp f (k, v) = Fmt.pf f "Analyse %a %s" Key.pp k (Value.digest v)
+
+  let run t job _key value =
+    remote_solve t job value >>!= fun response ->
+    match
+      Worker.Solve_response.of_yojson (Yojson.Safe.from_string response)
+    with
+    | Ok x -> Lwt.return x
+    | Error ex -> failwith ex
+
+  let auto_cancel = true
+  let latched = true
+end
+
+module Opam_hash = struct
+  type t = No_context
+
+  let current_hash = ref (-1)
+
+  module Key = struct
+    type t = string list [@@deriving yojson]
+
+    let digest t = to_yojson t |> Yojson.Safe.to_string
+  end
+
+  module Value = Current.String
+
+  let id = "opam-hash"
+
+  let build No_context job key =
+    let opam_repository_hash = key in
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    incr current_hash;
+    if !current_hash >= List.length opam_repository_hash then current_hash := 0;
+    let commit = List.nth opam_repository_hash !current_hash in
+    Current.Job.log job "Current opam repository_commit: %s@." commit;
+    Lwt.return @@ Ok commit
+
+  let pp f key = Fmt.pf f "opam-hash: %s" (Key.digest key)
+  let auto_cancel = false
+end
+
+module Platforms = struct
+  let id = "platforms"
+
+  type t = No_context
+
+  module Key = Current.String
+  (* module Value = Current.String *)
+
+  module Value = struct
+    type t = (string * Solver_service_api.Worker.Vars.t) list
+    [@@deriving yojson]
+
+    (* let digest t = to_yojson t |> Yojson.Safe.to_string *)
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error e -> failwith e
+  end
+
+  let pp f key = Fmt.pf f "platforms(%a):" Key.pp key
+
+  let build No_context job _key =
+    let ocaml_package_name = "ocaml-base-compiler" in
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Utils.get_vars ~ocaml_package_name ~ocaml_version:"none" () >>= fun vars ->
+    let platforms =
+      List.rev Ocaml_version.Releases.all_patches
+      |> List.filteri (fun i _ -> i < 8)
+      |> List.map (fun y ->
+             let platform =
+               (vars.os, { vars with ocaml_version = Ocaml_version.to_string y })
+             in
+             Current.Job.log job "%s@." (Value.marshal [ platform ]);
+             platform)
+    in
+    Lwt_result.return platforms
+
+  let auto_cancel = true
+end
+
+module Analysis_current = Current_cache.Generic (Analysis)
+module Packages_current = Current_cache.Generic (Packages)
+module Opam_hash_current = Current_cache.Make (Opam_hash)
+module Platforms_current = Current_cache.Make (Platforms)
+
+let platforms () =
+  Current.component "Platforms"
+  |> let> () = Current.return () in
+     Platforms_current.get Platforms.No_context "platforms-current"
+
+let opam_hash auto_cancel_time opam_repository_commits () =
+  Current.component "Opam-hash"
+  |> let> () = Current.return () in
+     let schedule =
+       (Current_cache.Schedule.v ~valid_for:(Duration.of_sec auto_cancel_time))
+         ()
+     in
+     Opam_hash_current.get ~schedule Opam_hash.No_context
+       opam_repository_commits
+
+let opam_packages limit =
+  Current.component "Opam-packages: %d" limit
+  |> let> () = Current.return () in
+     Packages_current.run Packages.No_context (string_of_int limit) limit
+
+let analyze platforms opam_repository_commit cluster opam_pkg =
+  Current.component "Analyse@.%s" (fst opam_pkg)
+  |> let> () = Current.return () in
+     let package = fst opam_pkg in
+     let make_request opam_pkg =
+       make_request opam_pkg opam_repository_commit |> fun req ->
+       { req with platforms }
+     in
+     Analysis_current.run cluster package (make_request opam_pkg)

--- a/stress/pipeline_stages.ml
+++ b/stress/pipeline_stages.ml
@@ -40,7 +40,6 @@ let make_request opam_package opam_repository_commit =
       root_pkgs = [ (String.cat package ".opam", opamfile) ];
       pinned_pkgs = [];
       platforms = [];
-      lower_bound = false;
     }
 
 module Packages = struct

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -29,7 +29,6 @@ let package_to_custom vars package =
       root_pkgs = [ (package, opamfile) ];
       pinned_pkgs = [];
       platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
-      lower_bound = false;
     }
 
 let requests log solver =

--- a/stress/stress_submit.ml
+++ b/stress/stress_submit.ml
@@ -1,172 +1,17 @@
-open Lwt.Infix
 open Current.Syntax
+open Pipeline_stages
 
-let ( >>!= ) = Lwt_result.bind
-
-let solve_to_custom req builder =
-  let params =
-    Yojson.Safe.to_string
-    @@ Solver_service_api.Worker.Solve_request.to_yojson req
-  in
-  let builder =
-    Solver_service_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
-  in
-  Solver_service_api.Raw.Builder.Solver.Solve.Params.request_set builder params
-
-let remote_solve cluster job request =
-  let action =
-    Cluster_api.Submission.custom_build
-    @@ Cluster_api.Custom.v ~kind:"solve"
-    @@ solve_to_custom request
-  in
-  let build_pool =
-    Current_ocluster.Connection.pool ~job ~pool:"solver" ~action ~cache_hint:""
-      cluster
-  in
-  Current.Job.start_with ~pool:build_pool job ~level:Current.Level.Average
-  >>= fun build_job ->
-  Capnp_rpc_lwt.Capability.with_ref build_job
-    (Current_ocluster.Connection.run_job ~job)
-
-let make_request opam_package opam_repository_commit =
-  let package, opamfile = opam_package in
-  Solver_service_api.Worker.Solve_request.
-    {
-      opam_repository_commits =
-        [
-          ( "https://github.com/ocaml/opam-repository.git",
-            opam_repository_commit );
-        ];
-      root_pkgs = [ (String.cat package ".opam", opamfile) ];
-      pinned_pkgs = [];
-      platforms = [];
-      lower_bound = false;
-    }
-
-let platforms = Ocaml_ci_service.Conf.fetch_platforms ~include_macos:false ()
-
-module Packages = struct
-  let id = "opam-packages"
-
-  type t = No_context
-
-  module Key = Current.String
-
-  module Value = struct
-    type t = int [@@deriving yojson]
-
-    let digest t = string_of_int t
-  end
-
-  module Outcome = struct
-    type t = (string * string) list [@@deriving yojson]
-    (** package name and opam file content*)
-
-    let marshal t = to_yojson t |> Yojson.Safe.to_string
-
-    let unmarshal s =
-      match Yojson.Safe.from_string s |> of_yojson with
-      | Ok x -> x
-      | Error e -> failwith e
-  end
-
-  let pp f (_, v) = Fmt.pf f "opam-packages: %s" (Value.digest v)
-
-  let run No_context job _key limit =
-    let open Lwt.Syntax in
-    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
-    Utils.get_opam_packages () >>= fun pkgs ->
-    pkgs
-    |> List.filteri (fun n _ -> if n < limit + 1 then true else false)
-    |> Lwt_list.mapi_s (fun id pkg ->
-           (* use sequential map to avoid crashing if there's a log of packages (like 100 or 200),
-            * this is because of get_opam_file which spawn a process*)
-           let* opamfile = Utils.get_opam_file pkg in
-           Current.Job.log job "package %d: %s@." id pkg;
-           Lwt.return (pkg, opamfile))
-    >>= Lwt_result.return
-
-  let auto_cancel = true
-  let latched = true
-end
-
-module Analysis = struct
-  open Solver_service_api
-
-  let id = "analysis"
-
-  type t = Current_ocluster.Connection.t
-
-  module Key = Current.String
-
-  module Value = struct
-    type t = Worker.Solve_request.t
-
-    let digest t = Worker.Solve_request.to_yojson t |> Yojson.Safe.to_string
-  end
-
-  module Outcome = struct
-    type t = Worker.Selection.t list [@@deriving yojson]
-
-    let marshal t = to_yojson t |> Yojson.Safe.to_string
-
-    let unmarshal s =
-      match Yojson.Safe.from_string s |> of_yojson with
-      | Ok x -> x
-      | Error e -> failwith e
-  end
-
-  let pp f (k, v) = Fmt.pf f "Analyse %a %s" Key.pp k (Value.digest v)
-
-  let run t job _key value =
-    remote_solve t job value >>!= fun response ->
-    match
-      Worker.Solve_response.of_yojson (Yojson.Safe.from_string response)
-    with
-    | Ok x -> Lwt.return x
-    | Error ex -> failwith ex
-
-  let auto_cancel = true
-  let latched = true
-end
-
-module Analysis_current = Current_cache.Generic (Analysis)
-module Packages_current = Current_cache.Generic (Packages)
-
-let opam_packages limit =
-  Current.component "Opam-packages: %d" limit
-  |> let> () = Current.return () in
-     Packages_current.run Packages.No_context (string_of_int limit) limit
-
-let analyze cluster request package =
-  Current.component "Analyse@.%s" package
-  |> let> () = Current.return () in
-     Analysis_current.run cluster package request
-
-let pipeline cluster opam_repository_commit packages =
-  Current.with_context packages @@ fun () ->
-  Current.with_context platforms @@ fun () ->
+let pipeline limit cluster opam_repository_commit =
   Current.component "Make-requests"
-  |> let** packages = packages and* platforms = platforms in
-     let platforms =
-       List.map
-         (fun (p : Ocaml_ci.Platform.t) ->
-           (Ocaml_ci.Variant.to_string p.variant, p.vars))
-         platforms
-     in
-     let make_request opam_pkg =
-       make_request opam_pkg opam_repository_commit |> fun req ->
-       { req with platforms }
-     in
+  |> let** packages = opam_packages limit and* platforms = platforms () in
      packages
      |> List.map (fun opam_pkg ->
             Current.ignore_value
-            @@ analyze cluster (make_request opam_pkg) (fst opam_pkg))
+            @@ analyze platforms opam_repository_commit cluster opam_pkg)
      |> Current.all
 
 let v cluster limit opam_repository_commit () =
-  let packages = opam_packages limit in
-  pipeline cluster opam_repository_commit packages
+  pipeline limit cluster opam_repository_commit
 
 let main config mode submission_uri limit opam_repository_commit =
   let vat = Capnp_rpc_unix.client_only_vat () in
@@ -189,7 +34,7 @@ let opam_repository_commit =
   Arg.value
   @@ Arg.opt Arg.string "a9fb5a379794b0d5d7f663ff3a3bed5d4672a5d3"
   @@ Arg.info ~doc:"The hash commit of opam-repository." ~docv:"COMMIT"
-       [ "opam-repository" ]
+       [ "opam-repository-commit" ]
 
 let submission_service =
   Arg.required
@@ -203,7 +48,9 @@ let request_limit =
   @@ Arg.info ~doc:"The number of requests to send" ~docv:"N" [ "limit" ]
 
 let cmd =
-  let doc = "Submit solve jobs to a scheduler that handles a solver-worker" in
+  let doc =
+    "Submit solve jobs to a scheduler that handles at least one solver-worker"
+  in
   let info = Cmd.info "stress_remote" ~doc in
   Cmd.v info
     Term.(

--- a/stress/stress_submit_auto_cancel.ml
+++ b/stress/stress_submit_auto_cancel.ml
@@ -1,0 +1,259 @@
+open Lwt.Infix
+open Current.Syntax
+
+let ( >>!= ) = Lwt_result.bind
+
+let solve_to_custom req builder =
+  let params =
+    Yojson.Safe.to_string
+    @@ Solver_service_api.Worker.Solve_request.to_yojson req
+  in
+  let builder =
+    Solver_service_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
+  in
+  Solver_service_api.Raw.Builder.Solver.Solve.Params.request_set builder params
+
+let remote_solve cluster job request =
+  let action =
+    Cluster_api.Submission.custom_build
+    @@ Cluster_api.Custom.v ~kind:"solve"
+    @@ solve_to_custom request
+  in
+  let build_pool =
+    Current_ocluster.Connection.pool ~job ~pool:"solver" ~action ~cache_hint:""
+      cluster
+  in
+  Current.Job.start_with ~pool:build_pool job ~level:Current.Level.Average
+  >>= fun build_job ->
+  Capnp_rpc_lwt.Capability.with_ref build_job
+    (Current_ocluster.Connection.run_job ~job)
+
+let make_request opam_package opam_repository_commit =
+  let package, opamfile = opam_package in
+  Solver_service_api.Worker.Solve_request.
+    {
+      opam_repository_commits =
+        [
+          ( "https://github.com/ocaml/opam-repository.git",
+            opam_repository_commit );
+        ];
+      root_pkgs = [ (String.cat package ".opam", opamfile) ];
+      pinned_pkgs = [];
+      platforms = [];
+      lower_bound = false;
+    }
+
+let platforms = Ocaml_ci_service.Conf.fetch_platforms ~include_macos:false ()
+
+module Packages = struct
+  let id = "opam-packages"
+
+  let pool = Lwt_pool.create 10 (fun () -> Lwt.return_unit)
+
+  type t = No_context
+
+  module Key = Current.String
+
+  module Value = struct
+    type t = int [@@deriving yojson]
+
+    let digest t = string_of_int t
+  end
+
+  module Outcome = struct
+    type t = (string * string) list [@@deriving yojson]
+    (** package name and opam file content*)
+
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error e -> failwith e
+  end
+
+  let pp f (_, v) = Fmt.pf f "opam-packages: %s" (Value.digest v)
+
+  let run No_context job _key limit =
+    let open Lwt.Syntax in
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Utils.get_opam_packages () >>= fun pkgs ->
+    pkgs
+    |> List.filteri (fun n _ -> if n < limit + 1 then true else false)
+    |> List.mapi (fun id pkg ->
+        (* use sequential map to avoid crashing if there's a log of packages (like 100 or 200),
+            * this is because of get_opam_file which spawn a process*)
+        Lwt_pool.use pool @@ fun () ->
+           let* opamfile = Utils.get_opam_file pkg in
+           Current.Job.log job "package %d: %s@." id pkg;
+           Lwt.return (pkg, opamfile))
+    |> Lwt_list.map_s (fun p -> p) >>= Lwt_result.return
+
+  let auto_cancel = true
+  let latched = true
+end
+
+module Analysis = struct
+  open Solver_service_api
+
+  let id = "analysis"
+
+  type t = Current_ocluster.Connection.t
+
+  module Key = Current.String
+
+  module Value = struct
+    type t = Worker.Solve_request.t
+
+    let digest t = Worker.Solve_request.to_yojson t |> Yojson.Safe.to_string
+  end
+
+  module Outcome = struct
+    type t = Worker.Selection.t list [@@deriving yojson]
+
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error e -> failwith e
+  end
+
+  let pp f (k, v) = Fmt.pf f "Analyse %a %s" Key.pp k (Value.digest v)
+
+  let run t job _key value =
+    remote_solve t job value >>!= fun response ->
+    match
+      Worker.Solve_response.of_yojson (Yojson.Safe.from_string response)
+    with
+    | Ok x -> Lwt.return x
+    | Error ex -> failwith ex
+
+  let auto_cancel = true
+  let latched = true
+end
+
+let opam_repository_hash = ref ["d0db19f581065173def5f086b8e0443f64609003";
+                                "5e382318663517d58b649820440cf9d41c50526a";
+                                "f18d48d31b11ad343aa285ad17ad55824f50d1b3"]
+
+module Opam_hash = struct
+    type t = No_context
+
+    let current_hash = ref (-1)
+
+    module Key = Current.String
+    module Value = Current.String
+
+    let id = "opam-hash"
+
+    let build No_context job _key =
+      Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+      incr current_hash;
+      if !current_hash >= List.length !opam_repository_hash then
+        current_hash := 0;
+      let commit = List.nth !opam_repository_hash !current_hash in
+      Current.Job.log job "opam repository_commit: %s@." commit;
+      Lwt.return @@ Ok commit
+
+    let pp f key = Fmt.pf f "opam-hash %a" Key.pp key
+
+    let auto_cancel = false
+  end
+
+module Analysis_current = Current_cache.Generic (Analysis)
+module Packages_current = Current_cache.Generic (Packages)
+module Opam_hash_current = Current_cache.Make (Opam_hash)
+
+let opam_hash () =
+  Current.component "Opam-hash"
+  |> let> () = Current.return () in
+  let schedule = (Current_cache.Schedule.v ~valid_for:(Duration.of_sec 80)) () in
+  Opam_hash_current.get ~schedule Opam_hash.No_context "opam-hash-current"
+
+let opam_packages limit =
+  Current.component "Opam-packages: %d" limit
+  |> let> () = Current.return () in
+     Packages_current.run Packages.No_context (string_of_int limit) limit
+
+let analyze platforms opam_repository_commit cluster opam_pkg =
+  Current.component "Analyse@.%s" (fst opam_pkg)
+  |> let> () = Current.return () in
+     let package = fst opam_pkg in
+     let make_request opam_pkg =
+       make_request opam_pkg opam_repository_commit |> fun req ->
+       { req with platforms }
+     in
+     Analysis_current.run cluster package (make_request opam_pkg)
+
+let pipeline cluster packages =
+  Current.with_context packages @@ fun () ->
+  Current.with_context platforms @@ fun () ->
+  Current.component "Make-requests"
+  |> let** packages = packages
+     and* opam_repository_commit = opam_hash ()
+     and* platforms = platforms in
+     let platforms =
+       List.map
+         (fun (p : Ocaml_ci.Platform.t) ->
+           (Ocaml_ci.Variant.to_string p.variant, p.vars))
+         platforms
+     in
+     packages
+     |> List.map (fun opam_pkg ->
+            Current.ignore_value
+            @@ analyze platforms opam_repository_commit cluster opam_pkg)
+     |> Current.all
+
+let v cluster limit _opam_repository_commit () =
+  let packages = opam_packages limit in
+  pipeline cluster packages
+
+let main config mode submission_uri limit opam_repository_commit =
+  let vat = Capnp_rpc_unix.client_only_vat () in
+  let submission_cap = Capnp_rpc_unix.Vat.import_exn vat submission_uri in
+  let cluster = Current_ocluster.Connection.create submission_cap in
+  let engine =
+    Current.Engine.create ~config (v cluster limit opam_repository_commit)
+  in
+  let site =
+    Current_web.Site.(v ~has_role:allow_all)
+      ~name:"submit-stress-analysis"
+      (Current_web.routes engine)
+  in
+  Lwt_main.run
+    (Lwt.choose [ Current.Engine.thread engine; Current_web.run ~mode site ])
+
+open Cmdliner
+
+let opam_repository_commit =
+  Arg.value
+  @@ Arg.opt Arg.string "a9fb5a379794b0d5d7f663ff3a3bed5d4672a5d3"
+  @@ Arg.info ~doc:"The hash commit of opam-repository." ~docv:"COMMIT"
+       [ "opam-repository" ]
+
+let submission_service =
+  Arg.required
+  @@ Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None
+  @@ Arg.info ~doc:"The submission.cap file for the build scheduler service"
+       ~docv:"FILE" [ "submission-service" ]
+
+let request_limit =
+  Arg.value
+  @@ Arg.opt Arg.int 30
+  @@ Arg.info ~doc:"The number of requests to send" ~docv:"N" [ "limit" ]
+
+let cmd =
+  let doc = "Submit solve jobs to a scheduler that handles a solver-worker" in
+  let info = Cmd.info "stress_remote" ~doc in
+  Cmd.v info
+    Term.(
+      term_result
+        (const main
+        $ Current.Config.cmdliner
+        $ Current_web.cmdliner
+        $ submission_service
+        $ request_limit
+        $ opam_repository_commit))
+
+let () = Cmd.(exit @@ eval cmd)

--- a/stress/stress_submit_auto_cancel.ml
+++ b/stress/stress_submit_auto_cancel.ml
@@ -1,220 +1,28 @@
-open Lwt.Infix
 open Current.Syntax
+open Pipeline_stages
 
-let ( >>!= ) = Lwt_result.bind
-
-let solve_to_custom req builder =
-  let params =
-    Yojson.Safe.to_string
-    @@ Solver_service_api.Worker.Solve_request.to_yojson req
-  in
-  let builder =
-    Solver_service_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
-  in
-  Solver_service_api.Raw.Builder.Solver.Solve.Params.request_set builder params
-
-let remote_solve cluster job request =
-  let action =
-    Cluster_api.Submission.custom_build
-    @@ Cluster_api.Custom.v ~kind:"solve"
-    @@ solve_to_custom request
-  in
-  let build_pool =
-    Current_ocluster.Connection.pool ~job ~pool:"solver" ~action ~cache_hint:""
-      cluster
-  in
-  Current.Job.start_with ~pool:build_pool job ~level:Current.Level.Average
-  >>= fun build_job ->
-  Capnp_rpc_lwt.Capability.with_ref build_job
-    (Current_ocluster.Connection.run_job ~job)
-
-let make_request opam_package opam_repository_commit =
-  let package, opamfile = opam_package in
-  Solver_service_api.Worker.Solve_request.
-    {
-      opam_repository_commits =
-        [
-          ( "https://github.com/ocaml/opam-repository.git",
-            opam_repository_commit );
-        ];
-      root_pkgs = [ (String.cat package ".opam", opamfile) ];
-      pinned_pkgs = [];
-      platforms = [];
-      lower_bound = false;
-    }
-
-let platforms = Ocaml_ci_service.Conf.fetch_platforms ~include_macos:false ()
-
-module Packages = struct
-  let id = "opam-packages"
-
-  let pool = Lwt_pool.create 10 (fun () -> Lwt.return_unit)
-
-  type t = No_context
-
-  module Key = Current.String
-
-  module Value = struct
-    type t = int [@@deriving yojson]
-
-    let digest t = string_of_int t
-  end
-
-  module Outcome = struct
-    type t = (string * string) list [@@deriving yojson]
-    (** package name and opam file content*)
-
-    let marshal t = to_yojson t |> Yojson.Safe.to_string
-
-    let unmarshal s =
-      match Yojson.Safe.from_string s |> of_yojson with
-      | Ok x -> x
-      | Error e -> failwith e
-  end
-
-  let pp f (_, v) = Fmt.pf f "opam-packages: %s" (Value.digest v)
-
-  let run No_context job _key limit =
-    let open Lwt.Syntax in
-    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
-    Utils.get_opam_packages () >>= fun pkgs ->
-    pkgs
-    |> List.filteri (fun n _ -> if n < limit + 1 then true else false)
-    |> List.mapi (fun id pkg ->
-        (* use sequential map to avoid crashing if there's a log of packages (like 100 or 200),
-            * this is because of get_opam_file which spawn a process*)
-        Lwt_pool.use pool @@ fun () ->
-           let* opamfile = Utils.get_opam_file pkg in
-           Current.Job.log job "package %d: %s@." id pkg;
-           Lwt.return (pkg, opamfile))
-    |> Lwt_list.map_s (fun p -> p) >>= Lwt_result.return
-
-  let auto_cancel = true
-  let latched = true
-end
-
-module Analysis = struct
-  open Solver_service_api
-
-  let id = "analysis"
-
-  type t = Current_ocluster.Connection.t
-
-  module Key = Current.String
-
-  module Value = struct
-    type t = Worker.Solve_request.t
-
-    let digest t = Worker.Solve_request.to_yojson t |> Yojson.Safe.to_string
-  end
-
-  module Outcome = struct
-    type t = Worker.Selection.t list [@@deriving yojson]
-
-    let marshal t = to_yojson t |> Yojson.Safe.to_string
-
-    let unmarshal s =
-      match Yojson.Safe.from_string s |> of_yojson with
-      | Ok x -> x
-      | Error e -> failwith e
-  end
-
-  let pp f (k, v) = Fmt.pf f "Analyse %a %s" Key.pp k (Value.digest v)
-
-  let run t job _key value =
-    remote_solve t job value >>!= fun response ->
-    match
-      Worker.Solve_response.of_yojson (Yojson.Safe.from_string response)
-    with
-    | Ok x -> Lwt.return x
-    | Error ex -> failwith ex
-
-  let auto_cancel = true
-  let latched = true
-end
-
-let opam_repository_hash = ref ["d0db19f581065173def5f086b8e0443f64609003";
-                                "5e382318663517d58b649820440cf9d41c50526a";
-                                "f18d48d31b11ad343aa285ad17ad55824f50d1b3"]
-
-module Opam_hash = struct
-    type t = No_context
-
-    let current_hash = ref (-1)
-
-    module Key = Current.String
-    module Value = Current.String
-
-    let id = "opam-hash"
-
-    let build No_context job _key =
-      Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
-      incr current_hash;
-      if !current_hash >= List.length !opam_repository_hash then
-        current_hash := 0;
-      let commit = List.nth !opam_repository_hash !current_hash in
-      Current.Job.log job "opam repository_commit: %s@." commit;
-      Lwt.return @@ Ok commit
-
-    let pp f key = Fmt.pf f "opam-hash %a" Key.pp key
-
-    let auto_cancel = false
-  end
-
-module Analysis_current = Current_cache.Generic (Analysis)
-module Packages_current = Current_cache.Generic (Packages)
-module Opam_hash_current = Current_cache.Make (Opam_hash)
-
-let opam_hash () =
-  Current.component "Opam-hash"
-  |> let> () = Current.return () in
-  let schedule = (Current_cache.Schedule.v ~valid_for:(Duration.of_sec 80)) () in
-  Opam_hash_current.get ~schedule Opam_hash.No_context "opam-hash-current"
-
-let opam_packages limit =
-  Current.component "Opam-packages: %d" limit
-  |> let> () = Current.return () in
-     Packages_current.run Packages.No_context (string_of_int limit) limit
-
-let analyze platforms opam_repository_commit cluster opam_pkg =
-  Current.component "Analyse@.%s" (fst opam_pkg)
-  |> let> () = Current.return () in
-     let package = fst opam_pkg in
-     let make_request opam_pkg =
-       make_request opam_pkg opam_repository_commit |> fun req ->
-       { req with platforms }
-     in
-     Analysis_current.run cluster package (make_request opam_pkg)
-
-let pipeline cluster packages =
-  Current.with_context packages @@ fun () ->
-  Current.with_context platforms @@ fun () ->
+let pipeline limit cluster time opam_repository_commit =
   Current.component "Make-requests"
-  |> let** packages = packages
-     and* opam_repository_commit = opam_hash ()
-     and* platforms = platforms in
-     let platforms =
-       List.map
-         (fun (p : Ocaml_ci.Platform.t) ->
-           (Ocaml_ci.Variant.to_string p.variant, p.vars))
-         platforms
-     in
+  |> let** packages = opam_packages limit
+     and* opam_repository_commit = opam_hash time opam_repository_commit ()
+     and* platforms = platforms () in
      packages
      |> List.map (fun opam_pkg ->
             Current.ignore_value
             @@ analyze platforms opam_repository_commit cluster opam_pkg)
      |> Current.all
 
-let v cluster limit _opam_repository_commit () =
-  let packages = opam_packages limit in
-  pipeline cluster packages
+let v cluster limit time opam_repository_commits () =
+  pipeline limit cluster time opam_repository_commits
 
-let main config mode submission_uri limit opam_repository_commit =
+let main config mode submission_uri limit auto_cancel_time
+    opam_repository_commits =
   let vat = Capnp_rpc_unix.client_only_vat () in
   let submission_cap = Capnp_rpc_unix.Vat.import_exn vat submission_uri in
   let cluster = Current_ocluster.Connection.create submission_cap in
   let engine =
-    Current.Engine.create ~config (v cluster limit opam_repository_commit)
+    Current.Engine.create ~config
+      (v cluster limit auto_cancel_time opam_repository_commits)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)
@@ -226,11 +34,18 @@ let main config mode submission_uri limit opam_repository_commit =
 
 open Cmdliner
 
-let opam_repository_commit =
+let opam_repository_commits =
   Arg.value
-  @@ Arg.opt Arg.string "a9fb5a379794b0d5d7f663ff3a3bed5d4672a5d3"
-  @@ Arg.info ~doc:"The hash commit of opam-repository." ~docv:"COMMIT"
-       [ "opam-repository" ]
+  @@ Arg.opt
+       (Arg.list ~sep:',' Arg.string)
+       [
+         "d0db19f581065173def5f086b8e0443f64609003";
+         "5e382318663517d58b649820440cf9d41c50526a";
+         "f18d48d31b11ad343aa285ad17ad55824f50d1b3";
+       ]
+  @@ Arg.info ~doc:"A list of opam opam-repository hash commits."
+       ~docv:"COMMITS"
+       [ "opam-repository-commits" ]
 
 let submission_service =
   Arg.required
@@ -243,9 +58,23 @@ let request_limit =
   @@ Arg.opt Arg.int 30
   @@ Arg.info ~doc:"The number of requests to send" ~docv:"N" [ "limit" ]
 
+let repository_time =
+  Arg.value
+  @@ Arg.opt Arg.int 80
+  @@ Arg.info
+       ~doc:
+         "Schedule how long an opam-repository commit remains, the new\n\
+         \  opam-repository commit is from the list \
+          $(b,opam-repository-commits). This scheduling triggers the \
+          auto-cancelling of analysis jobs."
+       ~docv:"N" [ "time" ]
+
 let cmd =
-  let doc = "Submit solve jobs to a scheduler that handles a solver-worker" in
-  let info = Cmd.info "stress_remote" ~doc in
+  let doc =
+    "Submit solve jobs to a scheduler that handles at least one solver-worker,\n\
+    \    [opam-repository-commits] is a list "
+  in
+  let info = Cmd.info "stress_remote_auto_cancelling" ~doc in
   Cmd.v info
     Term.(
       term_result
@@ -254,6 +83,7 @@ let cmd =
         $ Current_web.cmdliner
         $ submission_service
         $ request_limit
-        $ opam_repository_commit))
+        $ repository_time
+        $ opam_repository_commits))
 
 let () = Cmd.(exit @@ eval cmd)

--- a/stress/utils.ml
+++ b/stress/utils.ml
@@ -15,7 +15,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -26,6 +27,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -51,7 +51,6 @@ let test_good_packages _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        lower_bound = false;
       }
   in
   let+ process =
@@ -77,7 +76,6 @@ let test_error _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        lower_bound = false;
       }
   in
   let+ process =
@@ -109,17 +107,12 @@ let test_e2e _sw () =
         root_pkgs = [ ("yaml.3.0.0", "") ];
         pinned_pkgs = [];
         platforms = [ (os_id, vars) ];
-        lower_bound = false;
       }
   in
   let* service = Service.v ~n_workers:1 ~create_worker in
-  let* response =
+  let+ response =
     Solver_service_api.Solver.solve ~log:(job_log log) service req
   in
-  let req_lower_bound = { req with lower_bound = true } in
-  let+ response_lower_bound =
-    Solver_service_api.Solver.solve ~log:(job_log log) service req_lower_bound
-  in
   Alcotest.(check solver_response)
     "Same solve response"
     (Ok
@@ -129,21 +122,10 @@ let test_e2e _sw () =
            packages = [ "lwt.5.5.0"; "yaml.3.0.0" ];
            compat_pkgs = [ "yaml.3.0.0" ];
            commits;
+           lower_bound = false;
          };
        ])
-    response;
-  Alcotest.(check solver_response)
-    "Same solve response"
-    (Ok
-       [
-         {
-           id = os_id;
-           packages = [ "lwt.5.5.0"; "yaml.3.0.0" ];
-           compat_pkgs = [ "yaml.3.0.0" ];
-           commits;
-         };
-       ])
-    response_lower_bound
+    response
 
 let tests =
   Alcotest_lwt.

--- a/test/utils.ml
+++ b/test/utils.ml
@@ -15,7 +15,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -26,6 +27,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"


### PR DESCRIPTION
This PR is a stress test which reproduce the bug about `Auto-cancelling`. Pushing us to revert it again on OCaml-ci https://github.com/ocurrent/ocaml-ci/pull/768.

The bug is triggered when there's 2 or + consecutive new commits that pushed in https://github.com/ocaml/opam-repository which is separate by less than 5 min or around. The second push cause auto-cancelling in the CI and all the old request related to `opam-repository` are cancelled, but the solver-service doesn't cancel a job itself imediatly(olny notify a cancel at the worker level connected to the scheduler) which is supposed to happen with the current design of ocluster(submission) and that result with lot of jobs accumulated in the solver-service. The old jobs is taking time to finish  and the new requests are waiting.