### PR TITLE
Move lower-bound to `Vars.t` and `Selection.t`

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -15,6 +15,7 @@ module Vars = struct
     ocaml_package : string;
     ocaml_version : string;
     opam_version : string;
+    lower_bound : bool;
   }
   [@@deriving yojson]
 end
@@ -29,6 +30,7 @@ module Selection = struct
     commits : (string * string) list; [@deriving yojson]
         (** The commits in each opam-repository to use. A pair of the repo URL
             and the commit hash*)
+    lower_bound : bool;  (** Is this a lower-bound selection? *)
   }
   [@@deriving yojson, ord]
 end
@@ -43,8 +45,6 @@ module Solve_request = struct
     pinned_pkgs : (string * string) list;
         (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;  (** Possible build platforms, by ID. *)
-    lower_bound : bool;
-        (** Solve for the oldest possible versions instead of newest. *)
   }
   [@@deriving yojson]
 end

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -36,7 +36,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -47,6 +48,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"
@@ -72,7 +74,6 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
         root_pkgs = [ (pv, opam_file) ];
         pinned_pkgs = [];
         platforms = [ (platform.os, platform) ];
-        lower_bound = false;
       }
   in
   Capnp_rpc_lwt.Capability.with_ref (job_log stderr) @@ fun log ->

--- a/examples/solve.ml
+++ b/examples/solve.ml
@@ -101,7 +101,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Lwt_process.pread ("", [| "opam"; "config"; "expand"; opam_template arch |])
   in
@@ -111,6 +112,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"

--- a/examples/submit.ml
+++ b/examples/submit.ml
@@ -110,7 +110,6 @@ let pipeline ~cluster vars () =
         root_pkgs = opamfiles;
         pinned_pkgs = [];
         platforms = [ ("os", vars) ];
-        lower_bound = false;
       }
   in
   let selection =

--- a/service/service.ml
+++ b/service/service.ml
@@ -159,7 +159,6 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         platforms;
         root_pkgs;
         pinned_pkgs;
-        lower_bound = _;
       } =
         request
       in
@@ -213,7 +212,15 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
                      ~from:opam_repository_commits )
                  >|= fun commits ->
                  let compat_pkgs = List.map fst compatible_root_pkgs in
-                 (id, Ok { Worker.Selection.id; compat_pkgs; packages; commits }))
+                 ( id,
+                   Ok
+                     {
+                       Worker.Selection.id;
+                       compat_pkgs;
+                       packages;
+                       commits;
+                       lower_bound = vars.lower_bound;
+                     } ))
       >|= List.filter_map (fun (id, result) ->
               Log.info log "= %s =" id;
               match result with

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -29,7 +29,6 @@ let package_to_custom vars package =
       root_pkgs = [ (package, opamfile) ];
       pinned_pkgs = [];
       platforms = [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
-      lower_bound = false;
     }
 
 let requests log solver =

--- a/stress/stress_submit.ml
+++ b/stress/stress_submit.ml
@@ -51,7 +51,6 @@ let make_requests limit =
               pinned_pkgs = [];
               platforms =
                 [ ("macOS", vars); ("linux", vars); ("windows", vars) ];
-              lower_bound = false;
             }
         in
         (request :: requests, nth + 1))

--- a/stress/utils.ml
+++ b/stress/utils.ml
@@ -15,7 +15,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -26,6 +27,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -56,7 +56,6 @@ let test_good_packages _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        lower_bound = false;
       }
   in
   let+ process =
@@ -83,7 +82,6 @@ let test_error _sw () =
         root_pkgs = [];
         pinned_pkgs = [];
         platforms = [];
-        lower_bound = false;
       }
   in
   let+ process =
@@ -114,16 +112,11 @@ let test_e2e _sw () =
         root_pkgs = [ ("yaml.3.0.0", "") ];
         pinned_pkgs = [];
         platforms = [ (os_id, vars) ];
-        lower_bound = false;
       }
   in
   let* service = Service.v ~n_workers:1 ~create_worker in
-  let* response =
+  let+ response =
     Solver_service_api.Solver.solve ~log:(job_log log) service req
-  in
-  let req_lower_bound = { req with lower_bound = true } in
-  let+ response_lower_bound =
-    Solver_service_api.Solver.solve ~log:(job_log log) service req_lower_bound
   in
   Alcotest.(check solver_response)
     "Same solve response"
@@ -134,21 +127,10 @@ let test_e2e _sw () =
            packages = [ "lwt.5.5.0"; "yaml.3.0.0" ];
            compat_pkgs = [ "yaml.3.0.0" ];
            commits;
+           lower_bound = false;
          };
        ])
-    response;
-  Alcotest.(check solver_response)
-    "Same solve response lower bound"
-    (Ok
-       [
-         {
-           id = os_id;
-           packages = [ "lwt.5.5.0"; "yaml.3.0.0" ];
-           compat_pkgs = [ "yaml.3.0.0" ];
-           commits;
-         };
-       ])
-    response_lower_bound
+    response
 
 let tests =
   Alcotest_lwt.

--- a/test/utils.ml
+++ b/test/utils.ml
@@ -15,7 +15,8 @@ let opam_template arch =
 |}
     arch
 
-let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
+let get_vars ~ocaml_package_name ~ocaml_version ?arch ?(lower_bound = false) ()
+    =
   let+ vars =
     Solver_service.Process.pread
       ("", [| "opam"; "config"; "expand"; opam_template arch |])
@@ -26,6 +27,7 @@ let get_vars ~ocaml_package_name ~ocaml_version ?arch () =
         `Assoc
           (("ocaml_package", `String ocaml_package_name)
           :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
           :: items)
     | json ->
         Fmt.failwith "Unexpected JSON: %a"


### PR DESCRIPTION
Moves the ability to request a lower-bounds solve from `Solve_request.t` to `Vars.t` and `Selection.t`. This is a breaking change for OCaml-CI as it uses these structs directly, a PR for that will be opened shortly.

The reason for the change is that sending two solve requests that differ only in [lower_bound] causes race conditions writing to the OCurrent job log. It is much more natural to instead represent a lower-bound build with an explicitly different platform.