### PR TITLE
Fix bug: 'Bad frame from worker' and  'Channel_closed'

### DIFF
--- a/service/dune
+++ b/service/dune
@@ -22,6 +22,7 @@
   opam_repository_intf
   process
   remote_commit
+  internal_worker
   service
   solver
   solver_service))

--- a/service/internal_worker.ml
+++ b/service/internal_worker.ml
@@ -1,0 +1,37 @@
+open Lwt.Infix
+
+module Worker_process = struct
+  type state =
+    | Available
+    | Released
+    | Closed of Unix.process_status
+    | Failed of exn
+
+  type t = { process : Lwt_process.process; mutable state : state }
+
+  let create cmd = { process = Lwt_process.open_process cmd; state = Available }
+  let pid t = t.process#pid
+
+  let state t =
+    match Lwt.state t.process#status with
+    | Lwt.Sleep -> t.state
+    | Lwt.Fail ex -> Failed ex
+    | Lwt.Return status -> Closed status
+
+  let release t = t.state <- Released
+
+  let close t =
+    release t;
+    t.process#terminate;
+    t.process#close >|= fun status ->
+    t.state <- Closed status;
+    status
+
+  let read_line t = Lwt_io.read_line t.process#stdout
+  let write t msg = Lwt_io.write t.process#stdin msg
+
+  let read_into t len =
+    let buf = Bytes.create len in
+    Lwt_io.read_into_exactly t.process#stdout buf 0 len >|= fun () ->
+    Bytes.unsafe_to_string buf
+end

--- a/service/internal_worker.mli
+++ b/service/internal_worker.mli
@@ -1,0 +1,18 @@
+module Worker_process : sig
+  type state =
+    | Available
+    | Released
+    | Closed of Unix.process_status
+    | Failed of exn
+
+  type t = { process : Lwt_process.process; mutable state : state }
+
+  val create : Lwt_process.command -> t
+  val pid : t -> int
+  val state : t -> state
+  val read_line : t -> String.t Lwt.t
+  val write : t -> string -> unit Lwt.t
+  val read_into : t -> int -> string Lwt.t
+  val release : t -> unit
+  val close : t -> Unix.process_status Lwt.t
+end

--- a/service/main.ml
+++ b/service/main.ml
@@ -1,6 +1,7 @@
 open Solver_service
 open Lwt.Syntax
 module Service = Service.Make (Opam_repository)
+module Worker_process = Internal_worker.Worker_process
 
 let pp_timestamp f x =
   let open Unix in
@@ -70,7 +71,7 @@ let start_server address ~n_workers =
     let cmd =
       ("", [| Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits |])
     in
-    Lwt_process.open_process cmd
+    Worker_process.create cmd
   in
   let* service = Service.v ~n_workers ~create_worker in
   let restore = Capnp_rpc_net.Restorer.single service_id service in
@@ -103,7 +104,7 @@ let main () hash address sockpath n_workers =
                  Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits;
                |] )
            in
-           Lwt_process.open_process cmd
+           Worker_process.create cmd
          in
          let* service = Service.v ~n_workers ~create_worker in
          export service ~on:socket)

--- a/service/service.ml
+++ b/service/service.ml
@@ -4,6 +4,7 @@ module Worker = Solver_service_api.Worker
 module Log = Solver_service_api.Solver.Log
 module Selection = Worker.Selection
 module Store = Git_unix.Store
+module Worker_process = Internal_worker.Worker_process
 
 let oldest_commit = Lwt_pool.create 180 @@ fun _ -> Lwt.return_unit
 (* we are using at most 360 pipes at the same time and that's enough to keep the current
@@ -16,7 +17,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
 
     val create :
       n_workers:int ->
-      create_worker:(Remote_commit.t list -> Lwt_process.process) ->
+      create_worker:(Remote_commit.t list -> Worker_process.t) ->
       Remote_commit.t list ->
       t Lwt.t
 
@@ -25,7 +26,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
       log:Log.X.t Capability.t ->
       id:string ->
       Worker.Solve_request.t ->
-      Lwt_process.process ->
+      Worker_process.t ->
       (string list, string) result Lwt.t
 
     val handle :
@@ -37,22 +38,27 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
 
     val dispose : t -> unit Lwt.t
   end = struct
-    type t = Lwt_process.process Lwt_pool.t
+    type t = Worker_process.t Lwt_pool.t
 
-    let validate (worker : Lwt_process.process) =
-      match Lwt.state worker#status with
-      | Lwt.Sleep -> Lwt.return true
-      | Lwt.Fail ex -> Lwt.fail ex
-      | Lwt.Return status ->
-          Format.eprintf "Worker %d is dead (%a) - removing from pool@."
-            worker#pid Process.pp_status status;
+    let validate (worker : Worker_process.t) =
+      match Worker_process.state worker with
+      | Available -> Lwt.return true
+      | Released ->
+          Format.eprintf
+            "Worker %d is released - closing and removing from pool@."
+            (Worker_process.pid worker);
           Lwt.return false
+      | Closed status ->
+          Format.eprintf "Worker %d is closed (%a) - removing from pool@."
+            (Worker_process.pid worker)
+            Process.pp_status status;
+          Lwt.return false
+      | Failed ex -> Lwt.fail ex
 
-    let dispose (worker : Lwt_process.process) =
-      let pid = worker#pid in
+    let dispose (worker : Worker_process.t) =
+      let pid = Worker_process.pid worker in
       Fmt.epr "Terminating worker %d@." pid;
-      worker#terminate;
-      worker#close >|= function
+      Worker_process.close worker >|= function
       | Unix.WEXITED code ->
           Fmt.epr "Worker %d finished. Exited with code %d@." pid code
       | Unix.WSIGNALED code ->
@@ -92,15 +98,13 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
         Printf.sprintf "%d\n%s" (String.length request_str) request_str
       in
       let process =
-        Lwt_io.write worker#stdin request_str >>= fun () ->
-        Lwt_io.read_line worker#stdout >>= fun time ->
-        Lwt_io.read_line worker#stdout >>= fun len ->
+        Worker_process.write worker request_str >>= fun () ->
+        Worker_process.read_line worker >>= fun time ->
+        Worker_process.read_line worker >>= fun len ->
         match Astring.String.to_int len with
         | None -> Fmt.failwith "Bad frame from worker: time=%S len=%S" time len
         | Some len -> (
-            let buf = Bytes.create len in
-            Lwt_io.read_into_exactly worker#stdout buf 0 len >|= fun () ->
-            let results = Bytes.unsafe_to_string buf in
+            Worker_process.read_into worker len >|= fun results ->
             match results.[0] with
             | '+' ->
                 Log.info log "%s: found solution in %s s" id time;
@@ -119,8 +123,10 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
             | _ -> Fmt.failwith "BUG: bad output: %s" results)
       in
       ( Lwt_switch.add_hook (Some switch) @@ fun () ->
-        (*We kill the process when there's no response from the worker*)
+        (* Release the worker before cancelling the promise of the request, in order to prevent the
+         * workers's pool choosing the worker for another processing.*)
         if Lwt.state process = Lwt.Sleep then (
+          Worker_process.release worker;
           Lwt.cancel process;
           dispose worker)
         else Lwt.return_unit );

--- a/service/service.mli
+++ b/service/service.mli
@@ -5,7 +5,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
     val create :
       n_workers:int ->
-      create_worker:(Remote_commit.t list -> Lwt_process.process) ->
+      create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
       Remote_commit.t list ->
       t Lwt.t
 
@@ -14,7 +14,7 @@ module Make (_ : Opam_repository_intf.S) : sig
       log:Solver_service_api.Solver.Log.X.t Capnp_rpc_lwt.Capability.t ->
       id:string ->
       Solver_service_api.Worker.Solve_request.t ->
-      Lwt_process.process ->
+      Internal_worker.Worker_process.t ->
       (string list, string) result Lwt.t
     (** [process ~log ~id request process] will write the [request] to the stdin
         of [procress] and read [stdout] returning the packages. Information is
@@ -32,7 +32,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
   val v :
     n_workers:int ->
-    create_worker:(Remote_commit.t list -> Lwt_process.process) ->
+    create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
     Solver_service_api.Solver.t Lwt.t
   (** [v ~n_workers ~create_worker] is a solver service that distributes work to
       up to [n_workers] subprocesses, using [create_worker hash] to spawn new

--- a/service/solver_service.ml
+++ b/service/solver_service.ml
@@ -5,3 +5,4 @@ module Process = Process
 module Service = Service
 module Solver = Solver
 module Remote_commit = Remote_commit
+module Internal_worker = Internal_worker

--- a/worker/solver_worker.ml
+++ b/worker/solver_worker.ml
@@ -10,6 +10,7 @@ module Solver_request = struct
   module Worker = Solver_service_api.Worker
   module Log = Solver_service_api.Solver.Log
   module Service = Solver_service.Service.Make (Solver_service.Opam_repository)
+  module Worker_process = Solver_service.Internal_worker.Worker_process
 
   type t =
     ( Service.Epoch.t,
@@ -26,7 +27,7 @@ module Solver_request = struct
             Solver_service.Remote_commit.list_to_string commits;
           |] )
       in
-      Lwt_process.open_process cmd
+      Worker_process.create cmd
     in
     let create commits =
       Service.Epoch.create ~n_workers ~create_worker commits


### PR DESCRIPTION
This bug is caused when the pool reuse an internal-worker(worker process) which is going to be terminated because a kill signal is already sent to the internal-worker due to a job cancelling. The operating system take some time to kill a process when a kill signal is sent.

The 'Bad frame from worker' is when the controller try to read from that internal-worker(released and being terminated), in the previous use some part of internal-worker output is read.

There's also a current fail because of Lwt_io.Channel_closed. the the controller also start reading when the internal-worker is killed by the OS and all the channels are closed.

The fix is about having different states of an internal-worker to prevent those bugs.

 Some examples from OCaml-CI:
 ```
2023-06-09 11:57.17: Job failed: Error from solver: Failed: Bad frame from worker: time="    Rejected candidates:" len="      deployer.dev: Requires ocaml >= 4.13.0"
```
 https://ocaml.ci.dev:8100/job/2023-06-09/113534-ci-analyse-74e6c8
 ```
Lwt_io.Channel_closed("output")
Lwt_io.Channel_closed("output")
2023-06-07 15:10.56: Job failed: Error from solver: Failed: Build failed
```
https://ocaml.ci.dev:8100/job/2023-06-07/144726-ci-analyse-02c8c8