### PR TITLE
Reliability : Add a safeguard by tagging each request with an uid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,3 +2,5 @@
 
 * oldest_commits_with: fix caching (@emillon #35)
 * fix canceling a job solve when its switch is off (@moyodiallo #54)
+* fix bad frame from solver-process and closed channels (@moyodiallo #61)
+* reliability : add a safeguard by tagging each request with an uid (@moyodiallo #62)

--- a/dune-project
+++ b/dune-project
@@ -1,58 +1,93 @@
 (lang dune 3.7)
+
 (name solver-service)
 
 (generate_opam_files true)
-(source (github ocurrent/solver-service))
-(authors "talex5@gmail.com" "patrick@sirref.org")
-(maintainers "tim@tarides.com" "alpha@tarides.com")
+
+(source
+ (github ocurrent/solver-service))
+
+(authors talex5@gmail.com patrick@sirref.org)
+
+(maintainers tim@tarides.com alpha@tarides.com)
 
 (package
  (name solver-service)
  (synopsis "Choose package versions to test")
  (depends
-  (ocaml (>= 4.14.1))
-  (alcotest-lwt (and (>= 1.7.0) :with-test))
-  ; Examples dependencies
+  (uuidm
+   (>= 0.9.8))
+  (ocaml
+   (>= 4.14.1))
+  (alcotest-lwt
+   (and
+    (>= 1.7.0)
+    :with-test))
   (current_web :with-test)
   (current_github :with-test)
   (current_ocluster :with-test)
-  (ppx_deriving_yojson (>= 3.6.1))
-  (ppx_deriving (>= 5.1))
-  (yojson (>= 2.1.0))
-  (lwt (>= 5.6.1))
-  (logs (>= 0.7.0))
-  (fmt (>= 0.9.0))
-  (ocaml-version (>= 3.6.1))
-  (solver-service-api (= :version))
-  (dune-build-info (>= 3.8.0))
+  (ppx_deriving_yojson
+   (>= 3.6.1))
+  (ppx_deriving
+   (>= 5.1))
+  yojson
+  (lwt
+   (>= 5.6.1))
+  logs
+  fmt
+  (dune-build-info
+   (>= 3.7))
+  (ocaml-version
+   (>= 3.6.1))
+  (solver-service-api
+   (= :version))
   conf-libev
-  (opam-0install (>= 0.4.3))
-  (git-unix (>= 3.12.0))
-  (capnp-rpc-unix (>= 1.2.3)))
- (conflicts (carton (< 0.4.2))))
+  (opam-0install
+   (>= 0.4.3))
+  (git-unix
+   (>= 3.12.0))
+  (capnp-rpc-unix
+   (>= 1.2.3)))
+ (conflicts
+  (carton
+   (< 0.4.2))))
 
 (package
  (name solver-service-api)
  (synopsis "Cap'n Proto API for the solver service")
  (depends
-  (ocaml (>= 4.14.1))
-  (alcotest-lwt (and (>= 1.7.0) :with-test))
-  current_rpc                   ; Version pinned by git submodule
-  (capnp (>= 3.5.0))
-  (capnp-rpc-lwt (>= 1.2.3))
-  (ppx_deriving_yojson (>= 3.6.1))
-  (ppx_deriving (>= 5.1))))
+  (ocaml
+   (>= 4.14.1))
+  (alcotest-lwt
+   (and
+    (>= 1.7.0)
+    :with-test))
+  current_rpc
+  (capnp
+   (>= 3.5.0))
+  capnp-rpc-lwt
+  ppx_deriving
+  ppx_deriving_yojson))
 
 (package
  (name solver-worker)
  (synopsis "OCluster worker that can solve opam constraints")
  (depends
-  (ocaml (>= 4.14.1))
-  (alcotest-lwt (and (>= 1.7.0) :with-test))
+  (ocaml
+   (>= 4.14.1))
+  (alcotest-lwt
+   (and
+    (>= 1.7.0)
+    :with-test))
   ocluster-api
-  current                       ; Version pinned by git submodule
-  (prometheus-app (>= 1.2))
-  (logs (>= 0.7.0))
-  (fmt (>= 0.9.0))
-  (dune-build-info (>= 3.7))
-  (solver-service (= :version))))
+  current
+  (prometheus-app
+   (>= 1.2))
+  (logs
+   (>= 0.7.0))
+  (fmt
+   (>= 0.9.0))
+  (dune-build-info
+   (>= 3.7))
+  (solver-service
+   (= :version))))

--- a/service/dune
+++ b/service/dune
@@ -13,6 +13,7 @@
   ocaml-version
   dune-build-info
   str
+  uuidm
   fmt.cli
   fmt.tty)
  (modules

--- a/service/internal_worker.ml
+++ b/service/internal_worker.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Worker_process = struct
+module Solver_process = struct
   type state =
     | Available
     | Released
@@ -28,6 +28,7 @@ module Worker_process = struct
     status
 
   let read_line t = Lwt_io.read_line t.process#stdout
+  let write_line t msg = Lwt_io.write_line t.process#stdin msg
   let write t msg = Lwt_io.write t.process#stdin msg
 
   let read_into t len =

--- a/service/internal_worker.mli
+++ b/service/internal_worker.mli
@@ -1,4 +1,4 @@
-module Worker_process : sig
+module Solver_process : sig
   type state =
     | Available
     | Released
@@ -11,6 +11,7 @@ module Worker_process : sig
   val pid : t -> int
   val state : t -> state
   val read_line : t -> String.t Lwt.t
+  val write_line : t -> string -> unit Lwt.t
   val write : t -> string -> unit Lwt.t
   val read_into : t -> int -> string Lwt.t
   val release : t -> unit

--- a/service/main.ml
+++ b/service/main.ml
@@ -1,7 +1,7 @@
 open Solver_service
 open Lwt.Syntax
 module Service = Service.Make (Opam_repository)
-module Worker_process = Internal_worker.Worker_process
+module Solver_process = Internal_worker.Solver_process
 
 let pp_timestamp f x =
   let open Unix in
@@ -71,7 +71,7 @@ let start_server address ~n_workers =
     let cmd =
       ("", [| Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits |])
     in
-    Worker_process.create cmd
+    Solver_process.create cmd
   in
   let* service = Service.v ~n_workers ~create_worker in
   let restore = Capnp_rpc_net.Restorer.single service_id service in
@@ -104,7 +104,7 @@ let main () hash address sockpath n_workers =
                  Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits;
                |] )
            in
-           Worker_process.create cmd
+           Solver_process.create cmd
          in
          let* service = Service.v ~n_workers ~create_worker in
          export service ~on:socket)

--- a/service/service.mli
+++ b/service/service.mli
@@ -5,7 +5,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
     val create :
       n_workers:int ->
-      create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
+      create_worker:(Remote_commit.t list -> Internal_worker.Solver_process.t) ->
       Remote_commit.t list ->
       t Lwt.t
 
@@ -13,8 +13,9 @@ module Make (_ : Opam_repository_intf.S) : sig
       switch:Lwt_switch.t ->
       log:Solver_service_api.Solver.Log.X.t Capnp_rpc_lwt.Capability.t ->
       id:string ->
+      request_uid:string ->
       Solver_service_api.Worker.Solve_request.t ->
-      Internal_worker.Worker_process.t ->
+      Internal_worker.Solver_process.t ->
       (string list, string) result Lwt.t
     (** [process ~log ~id request process] will write the [request] to the stdin
         of [procress] and read [stdout] returning the packages. Information is
@@ -32,7 +33,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
   val v :
     n_workers:int ->
-    create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
+    create_worker:(Remote_commit.t list -> Internal_worker.Solver_process.t) ->
     Solver_service_api.Solver.t Lwt.t
   (** [v ~n_workers ~create_worker] is a solver service that distributes work to
       up to [n_workers] subprocesses, using [create_worker hash] to spawn new

--- a/solver-service-api.opam
+++ b/solver-service-api.opam
@@ -11,9 +11,9 @@ depends: [
   "alcotest-lwt" {>= "1.7.0" & with-test}
   "current_rpc"
   "capnp" {>= "3.5.0"}
-  "capnp-rpc-lwt" {>= "1.2.3"}
-  "ppx_deriving_yojson" {>= "3.6.1"}
-  "ppx_deriving" {>= "5.1"}
+  "capnp-rpc-lwt"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
   "odoc" {with-doc}
 ]
 build: [

--- a/solver-service.opam
+++ b/solver-service.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.7"}
+  "uuidm" {>= "0.9.8"}
   "ocaml" {>= "4.14.1"}
   "alcotest-lwt" {>= "1.7.0" & with-test}
   "current_web" {with-test}
@@ -14,13 +15,13 @@ depends: [
   "current_ocluster" {with-test}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "ppx_deriving" {>= "5.1"}
-  "yojson" {>= "2.1.0"}
+  "yojson"
   "lwt" {>= "5.6.1"}
-  "logs" {>= "0.7.0"}
-  "fmt" {>= "0.9.0"}
+  "logs"
+  "fmt"
+  "dune-build-info" {>= "3.7"}
   "ocaml-version" {>= "3.6.1"}
   "solver-service-api" {= version}
-  "dune-build-info" {>= "3.8.0"}
   "conf-libev"
   "opam-0install" {>= "0.4.3"}
   "git-unix" {>= "3.12.0"}

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
  (package solver-service)
- (libraries alcotest-lwt solver-service))
+ (libraries alcotest-lwt solver-service uuidm))

--- a/worker/solver_worker.ml
+++ b/worker/solver_worker.ml
@@ -10,7 +10,7 @@ module Solver_request = struct
   module Worker = Solver_service_api.Worker
   module Log = Solver_service_api.Solver.Log
   module Service = Solver_service.Service.Make (Solver_service.Opam_repository)
-  module Worker_process = Solver_service.Internal_worker.Worker_process
+  module Solver_process = Solver_service.Internal_worker.Solver_process
 
   type t =
     ( Service.Epoch.t,
@@ -27,7 +27,7 @@ module Solver_request = struct
             Solver_service.Remote_commit.list_to_string commits;
           |] )
       in
-      Worker_process.create cmd
+      Solver_process.create cmd
     in
     let create commits =
       Service.Epoch.create ~n_workers ~create_worker commits


### PR DESCRIPTION
The controller distribute a job request with an uid (request_uid) to a `solver-process`  pool. The goal is to prevent mixing the results coming from the `solver-pocess` pool.