### PR TITLE
Fix README example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:ubuntu-22.04-ocaml-4.14@sha256:6a39f49be26b7c085a4b1cca37920e04f5dcdc648dc96383ead337fb8db245b7 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 9681b042fa762f729225edb3214bfaec717498a1 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard f35584e0c472f68694d003e96ba513b1ca7b17c6 && opam update
 COPY --chown=opam solver-service.opam solver-service-api.opam solver-worker.opam /src/
 
 COPY --chown=opam \

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -108,7 +108,7 @@ let ocaml_version =
 
 let opam_commit =
   Arg.value
-  @@ Arg.(opt string "61c80509aec809b94b4ff7a505235f1ba605c756")
+  @@ Arg.(opt string "68755fe0f8ed7cc42b6403f77d0f7c01b4a6133b")
   @@ Arg.info [ "commit" ] ~docv:"COMMIT"
        ~doc:"The commit SHA to use for opam-repository"
 

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -79,12 +79,15 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
   let+ response = Solver_service_api.Solver.solve service ~log request in
   match response with
   | Ok selections ->
-    selections |> List.iter (fun selection ->
-        let packages = selection.Solver_service_api.Worker.Selection.packages in
-        Fmt.pr "opam install %a" Fmt.(list ~sep:(Fmt.any " ") string) packages
-      )
-  | Error (`Msg m) ->
-      Fmt.failwith "Solver service failed with: %s" m
+      selections
+      |> List.iter (fun selection ->
+             let packages =
+               selection.Solver_service_api.Worker.Selection.packages
+             in
+             Fmt.pr "opam install %a"
+               Fmt.(list ~sep:(Fmt.any " ") string)
+               packages)
+  | Error (`Msg m) -> Fmt.failwith "Solver service failed with: %s" m
   | Error `Cancelled -> Fmt.failwith "Job Cancelled"
 
 let connect package version ocaml_version opam_commit uri =

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -78,9 +78,11 @@ let run_client ~package ~version ~ocaml_version ~opam_commit service =
   Capnp_rpc_lwt.Capability.with_ref (job_log stderr) @@ fun log ->
   let+ response = Solver_service_api.Solver.solve service ~log request in
   match response with
-  | Ok selection ->
-      let packages = (List.hd @@ selection).packages in
-      Fmt.pr "opam install %a" Fmt.(list ~sep:(Fmt.any " ") string) packages
+  | Ok selections ->
+    selections |> List.iter (fun selection ->
+        let packages = selection.Solver_service_api.Worker.Selection.packages in
+        Fmt.pr "opam install %a" Fmt.(list ~sep:(Fmt.any " ") string) packages
+      )
   | Error (`Msg m) ->
       Fmt.failwith "Solver service failed with: %s" m
   | Error `Cancelled -> Fmt.failwith "Job Cancelled"


### PR DESCRIPTION
- In the example client, show the log in real-time and on success too. Otherwise, you can't see that the service is doing anything and if there are no solutions then you don't see why.
- Don't crash the example client if there is no solution.
- Update the default opam-repository commit so that the example in the README works.

Fixes #66.