### PR TITLE
Refactoring : rename Worker_process module

### DIFF
--- a/service/internal_worker.ml
+++ b/service/internal_worker.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Worker_process = struct
+module Solver_process = struct
   type state =
     | Available
     | Released

--- a/service/internal_worker.mli
+++ b/service/internal_worker.mli
@@ -1,4 +1,4 @@
-module Worker_process : sig
+module Solver_process : sig
   type state =
     | Available
     | Released

--- a/service/main.ml
+++ b/service/main.ml
@@ -1,7 +1,7 @@
 open Solver_service
 open Lwt.Syntax
 module Service = Service.Make (Opam_repository)
-module Worker_process = Internal_worker.Worker_process
+module Solver_process = Internal_worker.Solver_process
 
 let pp_timestamp f x =
   let open Unix in
@@ -71,7 +71,7 @@ let start_server address ~n_workers =
     let cmd =
       ("", [| Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits |])
     in
-    Worker_process.create cmd
+    Solver_process.create cmd
   in
   let* service = Service.v ~n_workers ~create_worker in
   let restore = Capnp_rpc_net.Restorer.single service_id service in
@@ -104,7 +104,7 @@ let main () hash address sockpath n_workers =
                  Sys.argv.(0); "--worker"; Remote_commit.list_to_string commits;
                |] )
            in
-           Worker_process.create cmd
+           Solver_process.create cmd
          in
          let* service = Service.v ~n_workers ~create_worker in
          export service ~on:socket)

--- a/service/service.ml
+++ b/service/service.ml
@@ -4,7 +4,7 @@ module Worker = Solver_service_api.Worker
 module Log = Solver_service_api.Solver.Log
 module Selection = Worker.Selection
 module Store = Git_unix.Store
-module Worker_process = Internal_worker.Worker_process
+module Solver_process = Internal_worker.Solver_process
 
 let oldest_commit = Lwt_pool.create 180 @@ fun _ -> Lwt.return_unit
 (* we are using at most 360 pipes at the same time and that's enough to keep the current
@@ -17,7 +17,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
 
     val create :
       n_workers:int ->
-      create_worker:(Remote_commit.t list -> Worker_process.t) ->
+      create_worker:(Remote_commit.t list -> Solver_process.t) ->
       Remote_commit.t list ->
       t Lwt.t
 
@@ -26,7 +26,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
       log:Log.X.t Capability.t ->
       id:string ->
       Worker.Solve_request.t ->
-      Worker_process.t ->
+      Solver_process.t ->
       (string list, string) result Lwt.t
 
     val handle :
@@ -38,27 +38,27 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
 
     val dispose : t -> unit Lwt.t
   end = struct
-    type t = Worker_process.t Lwt_pool.t
+    type t = Solver_process.t Lwt_pool.t
 
-    let validate (worker : Worker_process.t) =
-      match Worker_process.state worker with
+    let validate (worker : Solver_process.t) =
+      match Solver_process.state worker with
       | Available -> Lwt.return true
       | Released ->
           Format.eprintf
             "Worker %d is released - closing and removing from pool@."
-            (Worker_process.pid worker);
+            (Solver_process.pid worker);
           Lwt.return false
       | Closed status ->
           Format.eprintf "Worker %d is closed (%a) - removing from pool@."
-            (Worker_process.pid worker)
+            (Solver_process.pid worker)
             Process.pp_status status;
           Lwt.return false
       | Failed ex -> Lwt.fail ex
 
-    let dispose (worker : Worker_process.t) =
-      let pid = Worker_process.pid worker in
+    let dispose (worker : Solver_process.t) =
+      let pid = Solver_process.pid worker in
       Fmt.epr "Terminating worker %d@." pid;
-      Worker_process.close worker >|= function
+      Solver_process.close worker >|= function
       | Unix.WEXITED code ->
           Fmt.epr "Worker %d finished. Exited with code %d@." pid code
       | Unix.WSIGNALED code ->
@@ -100,14 +100,14 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
           Printf.sprintf "%d\n%s" (String.length request_str) request_str
         in
         let process =
-          Worker_process.write worker request_str >>= fun () ->
-          Worker_process.read_line worker >>= fun time ->
-          Worker_process.read_line worker >>= fun len ->
+          Solver_process.write worker request_str >>= fun () ->
+          Solver_process.read_line worker >>= fun time ->
+          Solver_process.read_line worker >>= fun len ->
           match Astring.String.to_int len with
           | None ->
               Fmt.failwith "Bad frame from worker: time=%S len=%S" time len
           | Some len -> (
-              Worker_process.read_into worker len >|= fun results ->
+              Solver_process.read_into worker len >|= fun results ->
               match results.[0] with
               | '+' ->
                   Log.info log "%s: found solution in %s s" id time;
@@ -130,7 +130,7 @@ module Make (Opam_repo : Opam_repository_intf.S) = struct
           (* Release the worker before cancelling the promise of the request, in order to prevent the
            * workers's pool choosing the worker for another processing.*)
           if Lwt.state process = Lwt.Sleep then (
-            Worker_process.release worker;
+            Solver_process.release worker;
             Lwt.cancel process;
             dispose worker)
           else Lwt.return_unit )

--- a/service/service.mli
+++ b/service/service.mli
@@ -5,7 +5,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
     val create :
       n_workers:int ->
-      create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
+      create_worker:(Remote_commit.t list -> Internal_worker.Solver_process.t) ->
       Remote_commit.t list ->
       t Lwt.t
 
@@ -14,7 +14,7 @@ module Make (_ : Opam_repository_intf.S) : sig
       log:Solver_service_api.Solver.Log.X.t Capnp_rpc_lwt.Capability.t ->
       id:string ->
       Solver_service_api.Worker.Solve_request.t ->
-      Internal_worker.Worker_process.t ->
+      Internal_worker.Solver_process.t ->
       (string list, string) result Lwt.t
     (** [process ~log ~id request process] will write the [request] to the stdin
         of [procress] and read [stdout] returning the packages. Information is
@@ -32,7 +32,7 @@ module Make (_ : Opam_repository_intf.S) : sig
 
   val v :
     n_workers:int ->
-    create_worker:(Remote_commit.t list -> Internal_worker.Worker_process.t) ->
+    create_worker:(Remote_commit.t list -> Internal_worker.Solver_process.t) ->
     Solver_service_api.Solver.t Lwt.t
   (** [v ~n_workers ~create_worker] is a solver service that distributes work to
       up to [n_workers] subprocesses, using [create_worker hash] to spawn new

--- a/test/test_service.ml
+++ b/test/test_service.ml
@@ -35,7 +35,7 @@ let const_response ~response : Lwt_process.process =
 
 let create_proc ~response =
   {
-    Solver_service.Internal_worker.Worker_process.process =
+    Solver_service.Internal_worker.Solver_process.process =
       const_response ~response;
     state = Available;
   }

--- a/worker/solver_worker.ml
+++ b/worker/solver_worker.ml
@@ -10,7 +10,7 @@ module Solver_request = struct
   module Worker = Solver_service_api.Worker
   module Log = Solver_service_api.Solver.Log
   module Service = Solver_service.Service.Make (Solver_service.Opam_repository)
-  module Worker_process = Solver_service.Internal_worker.Worker_process
+  module Solver_process = Solver_service.Internal_worker.Solver_process
 
   type t =
     ( Service.Epoch.t,
@@ -27,7 +27,7 @@ module Solver_request = struct
             Solver_service.Remote_commit.list_to_string commits;
           |] )
       in
-      Worker_process.create cmd
+      Solver_process.create cmd
     in
     let create commits =
       Service.Epoch.create ~n_workers ~create_worker commits


### PR DESCRIPTION
We have Solver_process instead of Worker_process to avoid conflicting with a Worker.