### PR TITLE
Filter root packages by "available" condition

### DIFF
--- a/service/domain_worker.mli
+++ b/service/domain_worker.mli
@@ -20,4 +20,7 @@ type reply = ((OpamPackage.t list, string) result * float, [`Msg of string]) res
     [Ok (Error msg)] if there is no solution.
     [Error msg] if the request was invalid. *)
 
+val env : Solver_service_api.Worker.Vars.t -> string -> OpamVariable.variable_contents option
+(** [env vars name] is the value of [name] in [vars]. *)
+
 val solve : request -> reply

--- a/test/test.expected
+++ b/test/test.expected
@@ -227,3 +227,22 @@ platforms: [debian-12-ocaml-5]
 Need to update opam-repo.git to get new commit 1bc28b8e8d98db6e524822c6f28bddebbc3504a3
 results:
   Cancelled
+
+# Available
+
+## foo-linux is only selected on Linux platform, but foo is selected for both ##
+
+commits: [(opam-repo.git, [ocaml-base-compiler.5.0])]
+root_pkgs: [foo.dev; foo-linux.dev]
+platforms: [linux; mac]
+results:
+  [linux:
+     compat_pkgs: [foo.dev; foo-linux.dev]
+     packages: [foo.dev; foo-linux.dev; ocaml-base-compiler.5.0]
+     commits: [(opam-repo.git, 1bc28b8e8d98db6e524822c6f28bddebbc3504a3)]
+     lower_bound: false;
+   mac:
+     compat_pkgs: [foo.dev]
+     packages: [foo.dev; ocaml-base-compiler.5.0]
+     commits: [(opam-repo.git, 1bc28b8e8d98db6e524822c6f28bddebbc3504a3)]
+     lower_bound: false]

--- a/test/test.ml
+++ b/test/test.ml
@@ -214,6 +214,23 @@ let test_cancel t =
     ~commits:[opam_repo, opam_packages]
     ~platforms
 
+let test_available t =
+  let opam_repo = Opam_repo.create "opam-repo.git" in
+  let opam_packages = [
+    "ocaml-base-compiler.5.0", "";
+  ] in
+  let root_pkgs = [
+    "foo.dev", "";
+    "foo-linux.dev", {| available: os = "linux" |};
+  ] in
+  solve t "foo-linux is only selected on Linux platform, but foo is selected for both"
+    ~root_pkgs
+    ~commits:[opam_repo, opam_packages]
+    ~platforms:[
+      "linux", debian_12_ocaml_5;
+      "mac", { debian_12_ocaml_5 with os = "macos" };
+    ]
+
 let () =
   Eio_main.run @@ fun env ->
   let domain_mgr = env#domain_mgr in
@@ -232,6 +249,7 @@ let () =
     "Multiple roots", test_multiple_roots;
     "Pinned", test_pinned;
     "Cancel", test_cancel;
+    "Available", test_available;
   ]
   |> List.iter (fun (name, fn) ->
       Fmt.pr "@.# %s@." name;


### PR DESCRIPTION
This is useful if some packages in a repository only work on certain platforms. For example, `eio_linux` should only be tested on Linux, but some other packages should still be tested on e.g. `macos`.

This is on top of #71 (until that's merged, see https://github.com/talex5/solver-service/compare/eio...talex5:solver-service:filter-avail?expand=1 for a more sensible diff).