### PR TITLE
Add --main-does-work hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-12-ocaml-5.1 AS build
+FROM ocaml/opam:debian-12-ocaml-5.2 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev libzstd-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard b61304c6db353e679a36720d8b914b029d6fbc0c && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard c6356412996ea3920dfded8fd10c15470acf3cd4 && opam update
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 COPY --chown=opam solver-service.opam solver-service-api.opam /src/
 WORKDIR /src

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -145,6 +145,12 @@ let version =
   | None -> "n/a"
   | Some v -> Build_info.V1.Version.to_string v
 
+let main_does_work =
+  Arg.value
+  @@ Arg.flag
+  @@ Arg.info ~doc:"Use main domain for work too (avoids GC slowness problem)"
+    [ "main-does-work" ]
+
 let () =
   let doc = "a service for selecting opam packages" in
   let info = Cmd.info "solver-service" ~doc ~version in
@@ -155,11 +161,11 @@ let () =
   Switch.run @@ fun sw ->
   Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
   let solver =
-    let make cache_dir n_workers =
+    let make cache_dir n_workers main_does_work =
       if not (Sys.file_exists cache_dir) then Unix.mkdir cache_dir 0o777;
-      Solver_service.Solver.create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers
+      Solver_service.Solver.create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers ~main_does_work
     in
-    Term.(const make $ cache_dir $ internal_workers)
+    Term.(const make $ cache_dir $ internal_workers $ main_does_work)
   in
   let run_service =
     let doc = "run solver as a stand-alone service" in

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
  (name solver-service)
  (synopsis "Choose package versions to test")
  (depends
-  (ocaml (>= 5.0.0))
+  (ocaml (>= 5.2.0))
   ; Examples dependencies
   (current_web (and (>= 0.6.4) :with-test))
   (current_git (and (>= 0.6.4) :with-test))

--- a/service/pool.ml
+++ b/service/pool.ml
@@ -1,14 +1,35 @@
 open Eio.Std
 
-type ('request, 'reply) t = ('request * 'reply Promise.u) Eio.Stream.t
+type ('request, 'reply) t = {
+  work : ('request * 'reply Promise.u) Eio.Stream.t;
+  do_main : Eio.Condition.t;
+}
 
 let rec run_worker t handle =
-  let request, set_reply = Eio.Stream.take t in
+  let request, set_reply = Eio.Stream.take t.work in
   handle request |> Promise.resolve set_reply;
   run_worker t handle
 
-let create ~sw ~domain_mgr ~n_workers handle =
-  let t = Eio.Stream.create 0 in
+(* OCaml currently requires all domains to synchronise for minor GCs.
+   Idle domains must be woken by the OS, which is slow.
+   As a work-around, we also run jobs in the main domain so it doesn't become idle.
+   This makes the service less responsive (e.g. at reporting progress messages)
+   but increases throughput. *)
+let run_main_worker t handle =
+  while true do
+    for _ = 1 to 10 do Fiber.yield () done;
+    match Eio.Stream.take_nonblocking t.work with
+    | None -> Eio.Condition.await_no_mutex t.do_main
+    | Some (request, set_reply) -> handle request |> Promise.resolve set_reply
+  done
+
+let create ~sw ~domain_mgr ~n_workers ~main_does_work handle =
+  let t = {
+    work = Eio.Stream.create 0;
+    do_main = Eio.Condition.create ();
+  } in
+  if main_does_work then
+    Fiber.fork_daemon ~sw (fun () -> run_main_worker t handle);
   for _i = 1 to n_workers do
     Fiber.fork_daemon ~sw (fun () ->
         Eio.Domain_manager.run domain_mgr (fun () -> run_worker t handle)
@@ -18,5 +39,13 @@ let create ~sw ~domain_mgr ~n_workers handle =
 
 let use t request =
   let reply, set_reply = Promise.create () in
-  Eio.Stream.add t (request, set_reply);
+  Eio.Stream.add t.work (request, set_reply);
   Promise.await reply
+
+(* Prod [run_main_worker] to run soon.
+   The service will call [use] multiple times after this,
+   adding to [work], which will get picked up first by the
+   worker domains. [run_main_worker] will then resume after that,
+   collecting any left-over work. *)
+let wake_main_later t =
+  Eio.Condition.broadcast t.do_main

--- a/service/solver.mli
+++ b/service/solver.mli
@@ -6,15 +6,17 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   cache_dir:string ->
   n_workers:int ->
+  main_does_work:bool ->
   t
-(** [create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers] is a solver service that
+(** [create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers ~main_does_work] is a solver service that
     distributes work between [n_workers] domains.
 
     @param sw Holds the worker domains.
     @param domain_mgr Used to spawn new domains.
     @param process_mgr Used to run the "git" command.
     @param cache_dir Directory for local git clones.
-    @param n_workers Maximum number of worker domains. *)
+    @param n_workers Maximum number of worker domains.
+    @param main_does_work Work around a problem with OCaml minor GCs being slow. *)
 
 val solve :
   ?cancelled:unit Eio.Promise.t ->

--- a/solver-service.opam
+++ b/solver-service.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.2.0"}
   "current_web" {>= "0.6.4" & with-test}
   "current_git" {>= "0.6.4" & with-test}
   "current_github" {>= "0.6.4" & with-test}

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -177,6 +177,7 @@ module Stress_local = struct
   type config = {
     cache_dir : string;
     n_workers : int;
+    main_does_work : bool;
   }
 
   let main ~domain_mgr ~process_mgr local config =
@@ -187,6 +188,7 @@ module Stress_local = struct
         ~process_mgr
         ~cache_dir:local.cache_dir
         ~n_workers:local.n_workers
+        ~main_does_work:local.main_does_work
     in
     let service = Solver_service.Service.v solver in
     benchmark config (fun request ->
@@ -202,6 +204,12 @@ module Stress_local = struct
     @@ Arg.info ~doc:"The number of sub-process solving requests in parallel"
       ~docv:"N" [ "internal-workers" ]
 
+  let main_does_work =
+    Arg.value
+    @@ Arg.flag
+    @@ Arg.info ~doc:"Use main domain for work too (avoids GC slowness problem)"
+      [ "main-does-work" ]
+
   let cache_dir =
     Arg.required
     @@ Arg.opt Arg.(some string) None
@@ -209,8 +217,8 @@ module Stress_local = struct
       [ "cache-dir" ]
 
   let config =
-    let make cache_dir n_workers = { cache_dir; n_workers } in
-    Term.(const make $ cache_dir $ internal_workers)
+    let make cache_dir n_workers main_does_work = { cache_dir; n_workers; main_does_work } in
+    Term.(const make $ cache_dir $ internal_workers $ main_does_work)
 end
 
 module Stress_service = struct

--- a/test/test.ml
+++ b/test/test.ml
@@ -238,7 +238,7 @@ let () =
   let cache_dir = "cache" in
   Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
   Switch.run @@ fun sw ->
-  let t = Solver_service.Solver.create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers:2 in
+  let t = Solver_service.Solver.create ~sw ~domain_mgr ~process_mgr ~cache_dir ~n_workers:2 ~main_does_work:false in
   [
     "Simple", test_simple;
     "Overlay", test_overlay;


### PR DESCRIPTION
OCaml currently requires all domains to synchronise for minor GCs. Idle domains must be woken by the OS, which is slow. As a work-around, this allows also running jobs in the main domain so it doesn't become idle. This makes the service less responsive (e.g. at reporting progress messages) but increases throughput.

See https://roscidus.com/blog/blog/2024/07/22/performance-2/

/cc @mtelvers 