### PR TITLE
Fix Invalid_argument("filter_deps")

### DIFF
--- a/service/git_context.ml
+++ b/service/git_context.ml
@@ -52,7 +52,7 @@ let filter_deps t pkg f =
   let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
   f
   |> OpamFilter.partial_filter_formula (env t pkg)
-  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev
+  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~dev_setup:false
        ~default:false
 
 let filter_available t pkg opam =

--- a/test/test.expected
+++ b/test/test.expected
@@ -246,3 +246,17 @@ results:
      packages: [foo.dev; ocaml-base-compiler.5.0]
      commits: [(opam-repo.git, 1bc28b8e8d98db6e524822c6f28bddebbc3504a3)]
      lower_bound: false]
+
+# with-dev-setup
+
+## foo depends on bar only using with-dev-setup ##
+
+commits: [(opam-repo.git, [ocaml-base-compiler.5.0])]
+root_pkgs: [foo.dev]
+platforms: [linux]
+results:
+  [linux:
+     compat_pkgs: [foo.dev]
+     packages: [foo.dev; ocaml-base-compiler.5.0]
+     commits: [(opam-repo.git, 1bc28b8e8d98db6e524822c6f28bddebbc3504a3)]
+     lower_bound: false]

--- a/test/test.ml
+++ b/test/test.ml
@@ -231,6 +231,21 @@ let test_available t =
       "mac", { debian_12_ocaml_5 with os = "macos" };
     ]
 
+let test_dev_setup t =
+  let opam_repo = Opam_repo.create "opam-repo.git" in
+  let opam_packages = [
+    "ocaml-base-compiler.5.0", "";
+  ] in
+  let root_pkgs = [
+    "foo.dev", {| depends: [ "bar" { with-dev-setup } ] |};
+  ] in
+  solve t "foo depends on bar only using with-dev-setup"
+    ~root_pkgs
+    ~commits:[opam_repo, opam_packages]
+    ~platforms:[
+      "linux", debian_12_ocaml_5;
+    ]
+
 let () =
   Eio_main.run @@ fun env ->
   let domain_mgr = env#domain_mgr in
@@ -250,6 +265,7 @@ let () =
     "Pinned", test_pinned;
     "Cancel", test_cancel;
     "Available", test_available;
+    "with-dev-setup", test_dev_setup;
   ]
   |> List.iter (fun (name, fn) ->
       Fmt.pr "@.# %s@." name;


### PR DESCRIPTION
The new version of opam crashes if the optional `dev_setup` argument isn't passed.

This is a quick fix while investigating what this is supposed to do...

/cc @mtelvers 