### PR TITLE
Fix example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-12-ocaml-5.2 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev libzstd-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 35e105c482ffb69e8f39679848310f4c1acd70c3 && opam update
-RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard e5d038c1515b66851c8191c55500786cee950833 && opam update
+RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam && opam option solver=builtin-0install && opam init --reinit -ni
 COPY --chown=opam solver-service.opam solver-service-api.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
  (name solver-service)
  (synopsis "Choose package versions to test")
  (depends
-  (ocaml (>= 5.0.0))
+  (ocaml (>= 5.1.0))
   ; Examples dependencies
   (current_web (and (>= 0.6.4) :with-test))
   (current_git (and (>= 0.6.4) :with-test))
@@ -21,8 +21,8 @@
   (ppx_deriving (>= 5.1))
   (yojson (>= 2.1.0))
   (lwt (>= 5.6.1))
-  (eio (>= 0.12))
-  (eio_main (>= 0.12))
+  (eio (>= 1.2))
+  (eio_main (>= 1.2))
   (lwt_eio (>= 0.5))
   (logs (>= 0.7.0))
   (fmt (>= 0.9.0))
@@ -39,8 +39,8 @@
   (git-unix (>= 3.12.0))
   (ocluster-api (>= 0.2.1))
   (prometheus-app (>= 1.2))
-  (capnp-rpc-net (>= 1.2.3))
-  (capnp-rpc-unix (>= 1.2.3)))
+  (capnp-rpc-net (and (>= 1.2.3) (< 2.0)))
+  (capnp-rpc-unix (and (>= 1.2.3) (< 2.0))))
  (conflicts (carton (< 0.4.2))))
 
 (package

--- a/examples/submit.ml
+++ b/examples/submit.ml
@@ -100,6 +100,8 @@ let pipeline ~cluster vars () =
       Current_github.Api.Anonymous.head_of opam_repository
         (`Ref "refs/heads/master")
     in
+    let { Solver_service_api.Worker.Vars.os; ocaml_version; _ } = vars in
+    let name = Fmt.str "%s-%s" os ocaml_version in
     Solver_service_api.Worker.Solve_request.
       {
         opam_repository_commits =
@@ -109,7 +111,7 @@ let pipeline ~cluster vars () =
           ];
         root_pkgs = opamfiles;
         pinned_pkgs = [];
-        platforms = [ ("os", vars) ];
+        platforms = [ (name, vars) ];
       }
   in
   let selection =
@@ -135,7 +137,7 @@ let main () config mode submission_uri =
   let open Lwt.Syntax in
   let vat = Capnp_rpc_unix.client_only_vat () in
   let* vars =
-    Solve.get_vars ~ocaml_package_name:"obuilder" ~ocaml_version:"4.13.1" ()
+    Solve.get_vars ~ocaml_package_name:"obuilder" ~ocaml_version:"5.2.0" ()
   in
   let submission_cap = Capnp_rpc_unix.Vat.import_exn vat submission_uri in
   let cluster = Current_ocluster.Connection.create submission_cap in

--- a/solver-service.opam
+++ b/solver-service.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocurrent/solver-service"
 bug-reports: "https://github.com/ocurrent/solver-service/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.1.0"}
   "current_web" {>= "0.6.4" & with-test}
   "current_git" {>= "0.6.4" & with-test}
   "current_github" {>= "0.6.4" & with-test}
@@ -18,8 +18,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "yojson" {>= "2.1.0"}
   "lwt" {>= "5.6.1"}
-  "eio" {>= "0.12"}
-  "eio_main" {>= "0.12"}
+  "eio" {>= "1.2"}
+  "eio_main" {>= "1.2"}
   "lwt_eio" {>= "0.5"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.9.0"}
@@ -34,8 +34,8 @@ depends: [
   "git-unix" {>= "3.12.0"}
   "ocluster-api" {>= "0.2.1"}
   "prometheus-app" {>= "1.2"}
-  "capnp-rpc-net" {>= "1.2.3"}
-  "capnp-rpc-unix" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
   "odoc" {with-doc}
 ]
 conflicts: [


### PR DESCRIPTION
The OCurrent example was trying to solve for the latest OBuilder with OCaml 4.13, which no
longer succeeds. I also changed the platform name from "os" to the actual platform so future such errors will be less confusing.

(I wonder if it's worth keeping the `submit.ml` example at all. It's quite complicated and pulls in OCurrent, including a web-server for the UI. I'm not sure it adds anything useful over the command-line example.)

I also made the startup code more consistent (using `Eio_main` everywhere and outside of cmdliner).